### PR TITLE
Withdrawn: consolidated V3.4 fork reconciliation

### DIFF
--- a/.github/comfy-cli-1.13.0-py310.constraints.txt
+++ b/.github/comfy-cli-1.13.0-py310.constraints.txt
@@ -1,0 +1,52 @@
+# Frozen dependency closure for comfy-cli 1.13.0 on CPython 3.10 / Linux.
+# The top-level comfy-cli wheel is separately pinned and SHA-256 verified by the
+# publish and publisher-toolchain workflows. Keep this file in sync when the
+# pinned Comfy CLI version changes.
+Jinja2==3.1.6
+MarkupSafe==3.0.3
+annotated-doc==0.0.5
+anyio==4.14.2
+arrow==1.4.0
+backoff==2.2.1
+binaryornot==0.6.0
+certifi==2026.7.22
+charset-normalizer==3.5.1
+click==8.4.2
+cookiecutter==2.7.1
+distro==1.9.0
+exceptiongroup==1.3.1
+gitdb==4.0.12
+gitpython==3.1.59
+h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
+idna==3.19
+markdown-it-py==4.2.0
+mdurl==0.1.2
+mixpanel==4.11.1
+packaging==26.3
+pathspec==1.1.1
+posthog==7.39.1
+prompt_toolkit==3.0.53
+psutil==7.2.2
+pygments==2.21.0
+python-dateutil==2.9.0.post0
+python-slugify==8.0.4
+pyyaml==6.0.3
+questionary==2.1.1
+requests==2.34.2
+rich==15.0.0
+ruff==0.16.3
+semver==3.0.4
+shellingham==1.5.4
+six==1.17.0
+smmap==5.0.3
+text-unidecode==1.3
+tomlkit==0.15.1
+typer==0.27.1
+typing-extensions==4.16.0
+tzdata==2026.3
+urllib3==2.7.0
+uv==0.12.5
+wcwidth==0.8.2
+websocket-client==1.9.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: Publish to Comfy registry
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+env:
+  COMFY_CLI_VERSION: "1.13.0"
+  COMFY_CLI_WHEEL_SHA256: "190108e4fa4fba44916f12eedbaca9ea685c2f9924c4370210092ccd17e6e5a8"
+  COMFY_CLI_CONSTRAINTS: ".github/comfy-cli-1.13.0-py310.constraints.txt"
+
+jobs:
+  publish-node:
+    name: Publish Custom Node to registry
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'ukr8b3g-cmyk' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Install verified Comfy CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_env="${RUNNER_TEMP}/h3-continuum-publish"
+          wheel_dir="${RUNNER_TEMP}/h3-continuum-comfy-cli"
+          python -m venv "${publish_env}"
+          mkdir -p "${wheel_dir}"
+
+          "${publish_env}/bin/python" -m pip download \
+            --disable-pip-version-check \
+            --no-deps \
+            --only-binary=:all: \
+            --dest "${wheel_dir}" \
+            "comfy-cli==${COMFY_CLI_VERSION}"
+
+          wheel="${wheel_dir}/comfy_cli-${COMFY_CLI_VERSION}-py3-none-any.whl"
+          test -f "${wheel}"
+          printf '%s  %s\n' "${COMFY_CLI_WHEEL_SHA256}" "${wheel}" | sha256sum --check --strict
+
+          "${publish_env}/bin/python" -m pip install \
+            --disable-pip-version-check \
+            --only-binary=:all: \
+            --constraint "${COMFY_CLI_CONSTRAINTS}" \
+            "${wheel}"
+
+          echo "PUBLISH_COMFY=${publish_env}/bin/comfy" >> "${GITHUB_ENV}"
+
+      - name: Initialize Comfy CLI environment
+        shell: bash
+        run: "${PUBLISH_COMFY} --skip-prompt --no-enable-telemetry env"
+
+      - name: Publish Custom Node
+        env:
+          REGISTRY_ACCESS_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+        shell: bash
+        run: "${PUBLISH_COMFY} node publish --token \"${REGISTRY_ACCESS_TOKEN}\""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,162 @@
+name: release
+
+on:
+  workflow_run:
+    workflows: [tests]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tested commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up release Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install release validation dependency
+        run: python -m pip install --disable-pip-version-check 'packaging==25.0'
+
+      - name: Detect tested version bump
+        id: version
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          version="$(python - <<'PY'
+          import pathlib
+          import tomllib
+
+          from packaging.version import InvalidVersion, Version
+
+          raw = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
+          try:
+              parsed = Version(raw)
+          except InvalidVersion as exc:
+              raise SystemExit(f"Invalid PEP 440 project version: {raw!r}: {exc}") from exc
+          if len(parsed.release) != 3:
+              raise SystemExit(
+                  f"Project version must have exactly three release components: {raw!r}"
+              )
+          print(parsed)
+          PY
+          )"
+
+          parent="$(git rev-parse "${RELEASE_SHA}^")"
+          previous_file="$(mktemp)"
+          trap 'rm -f "${previous_file}"' EXIT
+          git show "${parent}:pyproject.toml" > "${previous_file}"
+          previous="$(PREVIOUS_PYPROJECT="${previous_file}" python - <<'PY'
+          import os
+          import pathlib
+          import tomllib
+
+          from packaging.version import InvalidVersion, Version
+
+          raw = tomllib.loads(
+              pathlib.Path(os.environ["PREVIOUS_PYPROJECT"]).read_text()
+          )["project"]["version"]
+          try:
+              parsed = Version(raw)
+          except InvalidVersion as exc:
+              raise SystemExit(
+                  f"Invalid previous PEP 440 project version: {raw!r}: {exc}"
+              ) from exc
+          if len(parsed.release) != 3:
+              raise SystemExit(
+                  f"Previous project version must have exactly three release components: {raw!r}"
+              )
+          print(parsed)
+          PY
+          )"
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "tag=v${version}" >> "${GITHUB_OUTPUT}"
+          if [[ "${version}" == "${previous}" ]]; then
+            echo "release=false" >> "${GITHUB_OUTPUT}"
+            echo "Project version is unchanged (${version}); no release requested."
+          else
+            echo "release=true" >> "${GITHUB_OUTPUT}"
+            echo "Validated tested version bump: ${previous} -> ${version}."
+          fi
+
+      - name: Extract changelog notes
+        if: steps.version.outputs.release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+
+          version = os.environ["VERSION"]
+          text = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          match = re.search(
+              rf"(?ms)^##\s+{re.escape(version)}\s*$\n(.*?)(?=^##\s+|\Z)",
+              text,
+          )
+          if match is None:
+              raise SystemExit(
+                  f"CHANGELOG.md has no '## {version}' section; refusing to publish"
+              )
+          notes = match.group(1).strip()
+          if not notes:
+              raise SystemExit(f"CHANGELOG.md section {version} is empty")
+          pathlib.Path("/tmp/h3-continuum-release-notes.md").write_text(
+              notes + "\n", encoding="utf-8"
+          )
+          PY
+
+      - name: Build release archive
+        if: steps.version.outputs.release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          mkdir -p dist
+          archive="ComfyUI-H3-Continuum-v${VERSION}.zip"
+          git archive \
+            --format=zip \
+            --prefix="ComfyUI-H3-Continuum-v${VERSION}/" \
+            --output="dist/${archive}" \
+            HEAD
+          (cd dist && sha256sum "${archive}" > SHA256SUMS)
+
+      - name: Publish GitHub release
+        if: steps.version.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists; leaving it unchanged."
+            exit 0
+          fi
+          gh release create "${TAG}" \
+            dist/ComfyUI-H3-Continuum-v${VERSION}.zip \
+            dist/SHA256SUMS \
+            --target "${RELEASE_SHA}" \
+            --title "H3 Continuum ${TAG}" \
+            --notes-file /tmp/h3-continuum-release-notes.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,26 +2,153 @@ name: tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+env:
+  COMFY_CLI_VERSION: "1.13.0"
+  COMFY_CLI_WHEEL_SHA256: "190108e4fa4fba44916f12eedbaca9ea685c2f9924c4370210092ccd17e6e5a8"
+  COMFY_CLI_CONSTRAINTS: ".github/comfy-cli-1.13.0-py310.constraints.txt"
+
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          python-version: "3.11"
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
           cache: pip
+
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install --index-url https://download.pytorch.org/whl/cpu torch
-          python -m pip install -r requirements.txt numpy safetensors pytest
+          python -m pip install -r requirements.txt numpy safetensors pytest ruff 'packaging==25.0' 'tomli==2.2.1; python_version < "3.11"'
+
+      - name: Validate project metadata and release archive
+        shell: bash
+        run: |
+          version="$(python - <<'PY'
+          import pathlib
+
+          from packaging.version import InvalidVersion, Version
+
+          try:
+              import tomllib
+          except ModuleNotFoundError:
+              import tomli as tomllib
+
+          raw = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
+          try:
+              parsed = Version(raw)
+          except InvalidVersion as exc:
+              raise SystemExit(f"Invalid PEP 440 project version: {raw!r}: {exc}") from exc
+          if len(parsed.release) != 3:
+              raise SystemExit(
+                  f"Project version must have exactly three release components: {raw!r}"
+              )
+          print(parsed)
+          PY
+          )"
+          archive="/tmp/ComfyUI-H3-Continuum-v${version}.zip"
+          git archive \
+            --format=zip \
+            --prefix="ComfyUI-H3-Continuum-v${version}/" \
+            --output="${archive}" \
+            HEAD
+          ARCHIVE="${archive}" VERSION="${version}" python - <<'PY'
+          import os
+          import zipfile
+
+          prefix = f"ComfyUI-H3-Continuum-v{os.environ['VERSION']}/"
+          required = {
+              prefix + "__init__.py",
+              prefix + "pyproject.toml",
+              prefix + "v2/sequence.py",
+              prefix + "v2/context_diagnostics.py",
+              prefix + "v3/nodes.py",
+              prefix + "v3/driving_nodes.py",
+              prefix + "web/project_id.js",
+              prefix + "web/v34_ui.js",
+          }
+          with zipfile.ZipFile(os.environ["ARCHIVE"]) as archive:
+              names = set(archive.namelist())
+          missing = sorted(required - names)
+          if missing:
+              raise SystemExit(f"release archive is missing required files: {missing}")
+          if prefix + "v3/driving_nodes_impl.py" in names:
+              raise SystemExit("release archive unexpectedly contains obsolete v3/driving_nodes_impl.py")
+          PY
+
+      - name: Run targeted Ruff checks
+        run: python -m ruff check . --select E9,F63,F7,F82
+
+      - name: Check JavaScript syntax
+        run: |
+          node --check web/project_id.js
+          node --check web/v34_ui.js
+
       - name: Compile Python
         run: python -m compileall -q .
+
       - name: Run tests
         run: python -m pytest -q -p no:cacheprovider
+
+  publisher-toolchain:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Verify and smoke test Comfy CLI publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_env="${RUNNER_TEMP}/h3-continuum-publish-smoke"
+          wheel_dir="${RUNNER_TEMP}/h3-continuum-comfy-cli"
+          python -m venv "${publish_env}"
+          mkdir -p "${wheel_dir}"
+
+          "${publish_env}/bin/python" -m pip download \
+            --disable-pip-version-check \
+            --no-deps \
+            --only-binary=:all: \
+            --dest "${wheel_dir}" \
+            "comfy-cli==${COMFY_CLI_VERSION}"
+
+          wheel="${wheel_dir}/comfy_cli-${COMFY_CLI_VERSION}-py3-none-any.whl"
+          test -f "${wheel}"
+          printf '%s  %s\n' "${COMFY_CLI_WHEEL_SHA256}" "${wheel}" | sha256sum --check --strict
+
+          "${publish_env}/bin/python" -m pip install \
+            --disable-pip-version-check \
+            --only-binary=:all: \
+            --constraint "${COMFY_CLI_CONSTRAINTS}" \
+            "${wheel}"
+
+          "${publish_env}/bin/comfy" node publish --help >/dev/null

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,7 @@ jobs:
           required = {
               prefix + "__init__.py",
               prefix + "pyproject.toml",
+              prefix + "masked_continuation.py",
               prefix + "v2/sequence.py",
               prefix + "v2/context_diagnostics.py",
               prefix + "v3/nodes.py",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Added V3.4 **Native Masked — exact continuation** as the recommended/default exact chunk-continuation mechanism using ComfyUI Core MiniMax H3 per-token denoise masks from PR #15375.
+- Preserved **Guide / Motion Context** as a separate softer continuation method and kept V2/V3.3 workflow behavior on the legacy guide/RoPE path.
+- Reused accepted generated H3 video/audio latents directly for protected target prefixes without decode/re-encode, with exact 39-frame/65-audio-step generated-AV boundary validation.
+- Kept Driving Audio authoritative by protecting video only in that mode, retaining absolute source-audio guide slices, and preserving final source-audio assembly behavior.
+- Versioned Native Masked continuation chunk fingerprints/plans so Run Storage never silently reuses Guide chunks as Native Masked while preserving reusable chunk 1 where possible.
+- Kept Spectrum Interop API v1 Actual Prefix 2 independent of the old layout rewrite.
+- Added regression coverage and documentation for native masks, temporal mapping, references/keyframes, restartability, assembly, and compatibility requirements.
+
 ## 3.4.0
 
 - Completed the V3.4 runtime path from the public sampler through V3/V2 to `run_sequence()`.
@@ -16,7 +26,7 @@
 - Added `H3 Continuum Assemble + Seam` with stable Audio Seam Auto and guarded Video Seam Auto defaults.
 - Kept `Auto 2` as an experimental exposure-ramp extension without widening the visible option label.
 - Added native Reference Audio conditioning and retained up to three ordered Reference Images.
-- Preserved stable sampler Node IDs, Run Storage compatibility, Core VAE decode, and Spectrum Interop API v1 Actual Prefix 2 behavior.
+- Preserved stable sampler Node IDs, Run Storage compatibility, Core VAE Decode, and Spectrum Interop API v1 Actual Prefix 2 behavior.
 - Added consolidated runtime validation results and documented known Timeline Video and Auto 2 limitations.
 
 ## 3.2.4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Long-form MiniMax H3 video generation for ComfyUI with restartable chunks, persi
 
 ## Native masked continuation feature
 
-The current feature branch adds **Native Masked — exact continuation (Recommended)** as the V3.4 default for exact same-shot continuation. It uses the MiniMax H3 per-token denoise-mask implementation merged in ComfyUI PR #15375 (merge commit `ff6c8a8af144fc9e9e7bc436b1b202f9316848d8`) and requires a Core revision exposing that H3 mask API.
+V3.4 now includes **Native Masked — exact continuation (Recommended)** as the default for exact same-shot continuation. It uses the MiniMax H3 per-token denoise-mask implementation merged in ComfyUI PR #15375 (merge commit `ff6c8a8af144fc9e9e7bc436b1b202f9316848d8`) and requires a Core revision exposing that H3 mask API.
 
 For chunk 2 and later, Continuum copies the previous accepted H3 video latent tail directly into the start of the next target latent. With generated Audio Continuity enabled and no Driving Audio, it also copies the exactly aligned previous H3 audio latent tail. Native Core masks mark the copied prefix with `0 = preserve` and the new region with `1 = generate`.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Long-form MiniMax H3 video generation for ComfyUI with restartable chunks, persi
 
 > V3.4 is the current stable release. V3.3 legacy nodes remain available for existing workflows.
 
+## Native masked continuation feature
+
+The current feature branch adds **Native Masked — exact continuation (Recommended)** as the V3.4 default for exact same-shot continuation. It uses the MiniMax H3 per-token denoise-mask implementation merged in ComfyUI PR #15375 (merge commit `ff6c8a8af144fc9e9e7bc436b1b202f9316848d8`) and requires a Core revision exposing that H3 mask API.
+
+For chunk 2 and later, Continuum copies the previous accepted H3 video latent tail directly into the start of the next target latent. With generated Audio Continuity enabled and no Driving Audio, it also copies the exactly aligned previous H3 audio latent tail. Native Core masks mark the copied prefix with `0 = preserve` and the new region with `1 = generate`.
+
+This path does not turn the previous chunk into a Continuum `minimax_refs` block and does not use Continuum's `position_ids`/RoPE rewrite for the protected continuation data. The existing **Guide / Motion Context** method remains available for softer contextual influence and shot transitions. Existing V2/V3.3 nodes retain their Guide behavior.
+
+At 24 fps video and 40 Hz H3 audio, the current exact generated-AV profile is **39 video frames = 65 audio latent steps**. New V3.4 Native Masked workflows therefore default to **Strong — 39 frames**. Native video-only continuation can still use 5/22/39 frames. Explicit 5/22-frame Native Masked generated-audio continuation is rejected rather than rounded silently.
+
+Driving Audio remains authoritative source audio: Native Masked protects the video prefix, leaves generated target audio unprotected, applies the existing absolute-time Driving Audio guide slice, and final assembly still selects the preserved source audio.
+
+See [Native Masked AV Continuation](docs/NATIVE_MASKED_CONTINUATION.md) for the data flow, temporal math, Run Storage contract, reference/keyframe rules, Spectrum separation, and runtime validation checklist.
+
 ## What's new in V3.4
 
 V3.4 focuses on the two reference workflows that are most useful in normal production:
@@ -35,6 +49,8 @@ This is a usability and reliability decision, not a claim that the experimental 
 
 - [V3.4 standard](examples/workflows/MiniMax_H3_Continuum_V34.json)
 - [V3.4 Turbo](examples/workflows/MiniMax_H3_Continuum_V34_turbo.json)
+
+New V3.4 nodes and the maintained V3.4 templates default to `Continuation Method = Native Masked — exact continuation (Recommended)`. Saved legacy V3.4 graphs that do not serialize `continuation_method` are migrated on load to `Guide / Motion Context` so reopening them preserves their previous guide/RoPE generation semantics. For new Native Masked workflows with generated Audio Continuity enabled, use `Continuity = Strong — 39 frames` (or Auto, which resolves to the same exact AV boundary).
 
 The templates include optional external nodes such as Spectrum, Video Helper Suite, rgthree, EasyUse, and RTX Video Super Resolution. Install, replace, connect, or bypass them according to your installation. Media and acceleration choices remain under user control.
 
@@ -74,6 +90,7 @@ V3.4 removes or relaxes Continuum-only rejection rules that blocked otherwise ru
 - There is no model allowlist and no automatic model replacement.
 - The obsolete strict_compatibility control is removed from the V3.4 interface.
 - Current Core PackedLayout behavior is supported without requiring the removed legacy frame_count argument.
+- Native Masked continuation performs capability detection against Core's MiniMax H3 mask API and reports an actionable compatibility error when PR #15375-equivalent support is absent.
 
 Hard stops remain only for states that cannot execute safely, including corrupt latent topology, incompatible assembly data, invalid persisted revisions, or unusable mandatory payloads.
 
@@ -118,7 +135,7 @@ Main inputs:
 - model, clip, video_vae, sampler, sigmas
 - Sequence Prompt
 - first_frame, last_frame
-- reference_image_1 through reference_image_3
+- reference_image_1 through reference_image_8
 - Video Reference
 - driving_audio, audio_vae
 
@@ -132,6 +149,7 @@ Visible controls:
 
 - Prompt Format, chunks, chunk_seconds
 - width, height, continuity
+- Continuation Method: Native Masked or Guide / Motion Context
 - base_seed, control after generate
 - audio_continuity
 - Run Storage
@@ -193,6 +211,8 @@ Run Storage preserves completed chunks and can reuse them after restarting Comfy
 
 - Use a fixed seed for reproducible resume.
 - Changing persistent models, LoRAs, references, prompts, resolution, or sampling settings can create a new revision.
+- Native Masked and Guide continuation chunks use different generation contracts. Native mask contract changes also produce a different continuation-chunk fingerprint.
+- Chunk 1 has no continuation prefix and remains reusable when only the continuation method changes; incompatible chunk 2+ state is not silently reused.
 - Unknown upstream node classes no longer cause rejection by themselves; reuse still depends on compatible observable contracts and hashes.
 
 ## Spectrum interoperability
@@ -201,6 +221,7 @@ Spectrum is optional. Current Spectrum releases officially support H3 Continuum 
 
 - Chunk 1 uses the normal initial path.
 - Chunk 2 and later request Actual Prefix 2.
+- Native Masked keeps this request without using Continuum's layout/RoPE rewrite.
 - Successful continuation logs accepted H3 Continuum API v1, actual prefix=2.
 - Unsupported Spectrum versions fall back without a private patch.
 
@@ -262,7 +283,7 @@ Use a 24 fps source for `Video Reference`. `Load Video (Upload)` may accept file
 
 ## Current validation status
 
-V3.4 has been exercised locally with:
+V3.4 stable has been exercised locally with:
 
 - 1, 2, and 3 chunks
 - standard and Turbo paths
@@ -274,11 +295,15 @@ V3.4 has been exercised locally with:
 - Run Storage reuse and selected-chunk regeneration
 - Core VAE Decode and final assembly
 
-No OOM was observed in the cited recent local V3.4 checks, including two-chunk 800 x 800 runs. This is not a universal memory guarantee. Model precision, LoRAs, source resolution, optional nodes, GPU, and RAM affect memory use.
+The Native Masked feature adds automated coverage for exact target-prefix copying, video/audio mask semantics, temporal boundary validation, Guide separation, keyframe/reference coexistence, Run Storage method/version separation, Spectrum Actual Prefix request independence, source immutability, and the existing assembly/duration suite. A real current-Core H3 generation is still required before claiming perceptual/runtime validation of the new mechanism; use the precise checklist in `docs/NATIVE_MASKED_CONTINUATION.md`.
+
+No OOM was observed in the cited recent local V3.4 stable checks, including two-chunk 800 x 800 runs. This is not a universal memory guarantee. Model precision, LoRAs, source resolution, optional nodes, GPU, and RAM affect memory use.
 
 ## Limits
 
-- Continuation does not guarantee frame-perfect identity or motion.
+- Native Masked exact continuation requires ComfyUI Core with PR #15375-equivalent H3 mask support.
+- Generated-audio Native Masked continuation currently uses the 39-frame exact AV profile; explicit 5/22-frame generated-audio requests fail instead of shifting audio timing.
+- Guide / Motion Context remains model conditioning and does not freeze an exact target prefix.
 - Video Reference guides H3; it does not reproduce every source frame.
 - Driving Audio preserves selected audio, but visual lip synchronization remains model-dependent.
 - Match Output can be substantially slower than 0.4 MP or 0.6 MP.

--- a/conditioning.py
+++ b/conditioning.py
@@ -31,14 +31,24 @@ _MODE_LABELS = {
 def conditioning_mode_from_presence(
     *, has_first: bool, has_last: bool, has_reference: bool
 ) -> str:
-    if has_reference:
-        return CONDITIONING_MODE_REFERENCE
+    """Classify the temporal keyframe task while allowing reference augmentation.
+
+    MiniMax H3 reference blocks and first/last keyframes are orthogonal pieces of
+    conditioning. Core can start from Reference-to-Video conditioning and layer
+    keyframe guides on top, so a connected reference must not erase First/Last
+    semantics. Keeping the temporal keyframe mode when keyframes are present also
+    makes Run Storage fingerprint those keyframes while the separate reference
+    contract fingerprints the reference assets.
+    """
+
     if has_first and has_last:
         return CONDITIONING_MODE_FL2VA
     if has_first:
         return CONDITIONING_MODE_I2VA
     if has_last:
         return CONDITIONING_MODE_LAST_ONLY
+    if has_reference:
+        return CONDITIONING_MODE_REFERENCE
     return CONDITIONING_MODE_T2VA
 
 

--- a/constants.py
+++ b/constants.py
@@ -21,7 +21,14 @@ MARK_CONTEXT_FRAMES = "_h3cj_context_frames"
 MARK_AUDIO_CONTEXT = "_h3cj_audio_context"
 MARK_AUDIO_END_FRAME = "_h3cj_audio_end_frame"
 MARK_AUDIO_OVERHANG = "_h3cj_audio_overhang"
+
+# Stable, namespaced metadata carried on the native MiniMax H3 ref dict that
+# Continuum appends for the previous-chunk AV context. Third-party model patches
+# may inspect this contract without importing Continuum as a dependency.
 CONTINUUM_REFERENCE_METADATA_KEY = "_h3_continuum"
+CONTINUUM_REFERENCE_ROLE_VIDEO_CONTEXT = "video_context"
+CONTINUUM_REFERENCE_AUDIO_ROLE_AUDIO_CONTEXT = "audio_context"
+CONTINUUM_REFERENCE_PRESERVE_ROPE_KEY = "preserve_rope"
 CONTINUUM_INTEROP_KEY = "h3_continuum"
 CONTINUUM_INTEROP_API = 1
 CONTINUUM_ACTUAL_PREFIX_STEPS = 2

--- a/continuation.py
+++ b/continuation.py
@@ -96,6 +96,7 @@ def prepare_conditioning(
             "api": CONTINUUM_INTEROP_API,
             "role": "video_context",
             "audio_role": "audio_context" if audio_context is not None else None,
+            "preserve_rope": True,
         },
     }
     if audio_context is not None:

--- a/docs/NATIVE_MASKED_CONTINUATION.md
+++ b/docs/NATIVE_MASKED_CONTINUATION.md
@@ -1,0 +1,116 @@
+# Native Masked AV Continuation
+
+V3.4 supports two intentionally different H3 continuation mechanisms.
+
+## Native Masked Continuation
+
+**Native Masked — exact continuation (Recommended)** is the V3.4 default for same-shot chunk continuation. It requires the MiniMax H3 per-token denoise-mask support merged in ComfyUI PR #15375 (merge commit `ff6c8a8af144fc9e9e7bc436b1b202f9316848d8`) or a newer Core revision exposing the same H3 mask capabilities.
+
+For chunk 1, Continuum creates and samples a normal H3 target latent. There is no protected continuation prefix.
+
+For chunk N > 1, Continuum:
+
+1. loads the previous accepted chunk's generated H3 latent state from the normal in-memory/Run Storage contract;
+2. selects the final valid continuation window directly from the stored H3 video latent, plus the generated-audio latent when Audio Continuity is enabled and Driving Audio is absent;
+3. creates a fresh H3 target latent for chunk N;
+4. copies the selected video latent tail into the start of the new target video stream;
+5. copies the selected generated-audio tail into the start of the new target audio stream when generated-audio continuation is active;
+6. constructs native H3 `noise_mask` streams with `0 = preserve` and `1 = generate`;
+7. sends the target and mask through the normal ComfyUI sampler/Core MiniMax H3 path.
+
+The previous generated latent is never decoded merely to be VAE-encoded again. Stored source tensors stay CPU-resident and are treated as immutable input. The fresh target receives copies, so the new chunk does not alias the prior accepted chunk.
+
+Native Masked continuation does not encode the previous chunk as a `minimax_refs` continuation block. Continuum's legacy `PackedLayout.position_ids` rewrite is therefore not part of this path. Ordinary Core references and keyframes remain ordinary Core conditioning.
+
+## Guide / Motion Context
+
+**Guide / Motion Context** retains the earlier Continuum mechanism. The previous clip is supplied as native H3 guide/reference context, and Continuum maps that context onto the next target timeline with the existing layout/RoPE adapter.
+
+Use Guide / Motion Context when the previous shot should influence the next shot without freezing an exact generated prefix. It is useful for softer continuity and shot transitions. It remains available intentionally and is also the compatibility behavior of the existing V2/V3.3 nodes.
+
+## H3 temporal boundaries
+
+H3 video targets use the native `17k + 5` pixel-frame grid. Continuum's current video context profiles are 5, 22, and 39 frames. At 24 fps these correspond to 2, 7, and 12 video-latent temporal slots.
+
+Generated H3 audio uses a 40 Hz latent timeline. An exact shared AV continuation boundary must satisfy:
+
+```text
+context_frames * 40 / 24 = integer audio steps
+```
+
+For a valid H3 `17k + 5` video context, shared exact AV boundaries occur at 39, 90, 141, 192, ... frames. Among Continuum's current 5/22/39 profiles, 39 frames is the exact AV option:
+
+```text
+39 video frames at 24 fps = 1.625 s = 65 audio latent steps at 40 Hz
+```
+
+V3.4 therefore defaults new Native Masked workflows to **Strong — 39 frames**. With generated Audio Continuity enabled, `Auto` also resolves to 39 frames. Explicit 5- or 22-frame Native Masked generated-audio continuation is rejected with an actionable error instead of rounding the audio boundary. Those profiles remain valid for video-only Native Masked continuation and for Guide / Motion Context.
+
+## First frame, last frame, and references
+
+Chunk 1 keeps normal Core conditioning behavior.
+
+On continuation chunks, any target keyframe that lies inside the protected Native Masked prefix is removed because the copied latent prefix is already the frame-0 authority. This prevents a connected first-frame guide from competing with the preserved continuation latent. A last-frame guide remains valid when its resolved target position lies after the protected prefix.
+
+Reference images/Ref2VA, including V3.4's dynamic inputs up to 8 references, remain ordinary persistent H3 references. Video Reference and standalone reference-conditioning metadata also remain separate from continuation state. They are not marked as Continuum history and do not become part of the protected prefix contract.
+
+## Generated audio and Driving Audio
+
+With normal generated audio and Audio Continuity enabled, Native Masked continuation protects both the previous video tail and its exactly aligned generated-audio tail.
+
+With Audio Continuity disabled, only video is protected; the entire new target audio stream remains generatable.
+
+Driving Audio has different semantics. It is authoritative source audio for the final timeline. While Driving Audio is active, Continuum does not reuse the previous generated audio as continuation input in either Native Masked or Guide / Motion Context mode. Native Masked protects the previous video tail and leaves the target audio mask fully generatable. Guide / Motion Context likewise supplies only previous video context. Continuum then attaches the existing absolute-time Driving Audio guide slice for the full chunk target, including the repeated video-prefix interval in Native Masked mode. Final assembly still selects the preserved source audio and bypasses generated-audio seam processing.
+
+This keeps one audio authority and preserves the existing absolute source-timeline alignment.
+
+## Assembly
+
+Native Masked continuation deliberately repeats the protected prefix at the start of chunk N > 1. The existing chunk plan records the same `trim_frames = context_frames` overlap used by assembly. Decode/assembly removes that repeated prefix once, preserving the current cumulative audio-boundary math, final frame count, and seam-processing contract.
+
+Seam correction remains available. Native masking improves the generative boundary but does not make all decoded seam correction unnecessary.
+
+## Run Storage and restartability
+
+Native Masked uses mask contract version `1`.
+
+Run Storage salts continuation-chunk generation fingerprints with the continuation method and mask-contract version. Chunk 1 has no continuation prefix, so its prompt fingerprint is intentionally unchanged and can be reused when only the continuation backend changes. Chunk 2 and later are never reused across Guide and Native Masked contracts.
+
+Native continuation chunk plans and Session settings persist the method and mask-contract version. Legacy stored continuation chunks without those fields are treated as Guide chunks. Regenerating from a later Native Masked chunk uses the immediately preceding accepted chunk's stored CPU latent as the continuation source.
+
+## Spectrum interoperability
+
+Spectrum's Continuum interoperability request is separate from the continuation representation. Chunk 2 and later still request H3 Continuum Interop API v1 with an Actual Prefix of 2 sampler steps.
+
+Native Masked does not require `patch_layout_in_place()` to make this request work. The three responsibilities remain independent:
+
+- ComfyUI Core owns per-token video/audio denoise-mask mechanics;
+- Continuum owns target-prefix construction, persistence, and assembly trimming;
+- Spectrum owns forecast safety and the requested actual sampler prefix.
+
+Spectrum remains optional. No Spectrum companion change is required for this contract.
+
+## Compatibility and migration
+
+Native Masked checks for the actual Core H3 mask API rather than relying only on a package version string. If the required API is missing, V3.4 reports the missing capability and identifies ComfyUI PR #15375 / merge commit `ff6c8a8af144fc9e9e7bc436b1b202f9316848d8` as the minimum implementation point.
+
+As of August 20, 2026, the latest tagged ComfyUI release is v0.31.0 from August 8, which predates the August 18 merge of #15375. Until a tagged release contains that implementation, Native Masked requires `ff6c8a8af144fc9e9e7bc436b1b202f9316848d8` or a newer Core `master` revision.
+
+Guide / Motion Context remains available on older supported Core builds that satisfy Continuum's existing guide/runtime requirements.
+
+Existing V3.3 nodes retain Guide behavior. Existing V3.4 workflows created before Native Masked are migrated to Guide / Motion Context on load so their old continuation semantics remain stable. The maintained V3.4 example workflows explicitly serialize Native Masked with Strong — 39 frames.
+
+## Runtime validation checklist
+
+CI validates latent copying/masks, boundary mapping, method routing, references/keyframes, Run Storage identity, source immutability, Spectrum request independence, and existing assembly/duration behavior. A real H3 model run is still required to assess perceptual seam quality and model-level interaction beyond those contracts.
+
+Recommended runtime validation:
+
+- current ComfyUI containing PR #15375;
+- H3 FL2VA model with normal Video VAE and Audio VAE;
+- V3.4 sampler, `Continuation Method = Native Masked — exact continuation (Recommended)`;
+- `Continuity = Strong — 39 frames`, `Audio Continuity = enabled`;
+- 2 x 5 s chunks at a normal production resolution and fixed seed;
+- test once with Spectrum absent and once with current Spectrum enabled;
+- repeat with Driving Audio, a last-frame guide, Ref2VA references, and Video Reference as separate cases;
+- verify the final assembled duration, no duplicated 39-frame prefix, no audio shift, and expected continuity at the seam.

--- a/docs/REFERENCE_INTEROP.md
+++ b/docs/REFERENCE_INTEROP.md
@@ -1,0 +1,38 @@
+# H3 Continuum reference interoperability contract
+
+H3 Continuum carries the previous chunk into the next MiniMax H3 call as a normal native `minimax_refs` entry. That reference is a continuation anchor, not an ordinary user reference.
+
+## Stable metadata
+
+The continuation reference contains the namespaced dictionary:
+
+```python
+ref["_h3_continuum"] = {
+    "api": 1,
+    "role": "video_context",
+    "audio_role": "audio_context" or None,
+    "preserve_rope": True,
+}
+```
+
+This metadata is intentionally suitable for third-party model patches to inspect without importing H3 Continuum.
+
+`preserve_rope=True` means the reference provides temporal/geometric continuity and should keep native H3 positional/RoPE treatment by default. A patch that changes reference positional frequencies, positional embeddings, reference-key RoPE channels, or equivalent geometry-sensitive attention state should exclude this reference unless the user explicitly requests otherwise.
+
+## Native packing
+
+ComfyUI's native H3 `PackedLayout` still owns the actual packed rows. A Continuum `video` or `video_audio` reference produces visual rows with segment kind `ref_img` (plus `ref_audio` rows when audio is present). Therefore consumers must not identify user image references from `layout.segments` alone.
+
+To distinguish references correctly:
+
+1. read `minimax_payload["refs"]` in native order;
+2. read `minimax_payload["layout"].segments`;
+3. pair each visual native ref (`image`, `video`, `video_audio`) with the corresponding `ref_img` segment in order;
+4. inspect `_h3_continuum` on the paired ref;
+5. fail closed if the number/order cannot be reconciled.
+
+This avoids accidentally treating the previous-chunk Continuum context as a normal image/style reference.
+
+## Compatibility
+
+The contract is additive. Native H3 ignores unknown keys on the ref dictionary, so normal ComfyUI packing remains unchanged. Existing internal `_h3cj_*` markers remain for Continuum's own compatibility logic; external consumers should prefer `_h3_continuum`.

--- a/docs/V34_HYBRID_CONDITIONING.md
+++ b/docs/V34_HYBRID_CONDITIONING.md
@@ -1,0 +1,51 @@
+# V3.4 hybrid First / Last / Reference conditioning
+
+V3.4 treats Reference Images and temporal keyframes as orthogonal MiniMax H3 conditioning.
+
+## Contract
+
+- `Reference Image 1..8` build persistent `minimax_refs` blocks and the Qwen reference presentation (`<Picture N>`).
+- `First Frame` is a frame-0 keyframe guide.
+- `Last Frame` is a keyframe guide at the final frame of the generated target.
+- Connecting one or more Reference Images does **not** disable or discard First Frame or Last Frame.
+
+This mirrors the Core H3 composition model: reference conditioning can be created first and keyframe guides can then be layered onto the same conditioning payload.
+
+## Supported input combinations
+
+| First Frame | Last Frame | Reference Image(s) | Temporal mode | Reference blocks |
+|---|---|---|---|---|
+| no | no | no | T2VA | none |
+| yes | no | no | I2VA | none |
+| no | yes | no | Last-only | none |
+| yes | yes | no | FL2VA | none |
+| no | no | yes | Reference | present |
+| yes | no | yes | I2VA | present |
+| no | yes | yes | Last-only | present |
+| yes | yes | yes | FL2VA | present |
+
+The temporal mode is used for keyframe and persistence semantics. Reference assets are fingerprinted separately and remain active whenever connected.
+
+## Continuation methods
+
+### Native Masked
+
+For chunk 2 and later, the protected continuation prefix is copied into the new target latent and masked against denoising. A First Frame keyframe at frame 0 is removed from continuation-chunk conditioning because it would compete with that protected prefix. Persistent Reference blocks remain. A Last Frame keyframe remains on the final target because it is outside the protected prefix.
+
+### Guide / Motion Context
+
+For chunk 2 and later, Continuum context replaces the old frame-0 keyframe according to the normal recommended continuation policy. Persistent Reference blocks remain, the continuation context reference is appended, and a final Last Frame keyframe is moved to the final frame of the expanded continuation target.
+
+## Run Storage
+
+Hybrid inputs are fingerprinted independently:
+
+- First Frame participates in the global I2VA/FL2VA sampling contract, so changing it invalidates all stored chunks for that revision.
+- Reference Images participate in the separate reference contract, so changing the active references invalidates the corresponding sampling revision.
+- Last Frame participates in the final chunk contract, so changing only Last Frame preserves reusable earlier chunks and invalidates the final chunk.
+
+This prevents a saved Reference run from reusing stale chunks after a hybrid First/Last keyframe changes.
+
+## Dynamic references
+
+The V3.4 public facade exposes Reference Image inputs through 8. Inputs 4..8 are compacted internally before entering the stable inherited sampler signature, without changing First/Last behavior. Active references retain connection order and are presented as contiguous `<Picture 1>..<Picture N>` references.

--- a/examples/workflows/MiniMax_H3_Continuum_V34.json
+++ b/examples/workflows/MiniMax_H3_Continuum_V34.json
@@ -1947,7 +1947,7 @@
         5,
         1344,
         768,
-        "Balanced — 22 frames",
+        "Strong — 39 frames",
         123456,
         "randomize",
         true,
@@ -1961,7 +1961,8 @@
         "",
         "Match Output",
         "178937a7-0b65-4964-b312-387ca0bdd733",
-        "Balanced - 0.6 MP"
+        "Balanced - 0.6 MP",
+        "Native Masked — exact continuation (Recommended)"
       ],
       "widgets_values_named": {
         "prompt_mode": "Auto",
@@ -1969,7 +1970,7 @@
         "chunk_seconds": 5,
         "width": 1344,
         "height": 768,
-        "continuity": "Balanced — 22 frames",
+        "continuity": "Strong — 39 frames",
         "base_seed": 123456,
         "control_after_generate": "randomize",
         "audio_continuity": true,
@@ -1983,7 +1984,8 @@
         "run_name": "",
         "reference_size": "Match Output",
         "project_id": "178937a7-0b65-4964-b312-387ca0bdd733",
-        "video_reference_size": "Balanced - 0.6 MP"
+        "video_reference_size": "Balanced - 0.6 MP",
+        "continuation_method": "Native Masked — exact continuation (Recommended)"
       },
       "color": "#232",
       "bgcolor": "#353"

--- a/examples/workflows/MiniMax_H3_Continuum_V34_turbo.json
+++ b/examples/workflows/MiniMax_H3_Continuum_V34_turbo.json
@@ -1698,7 +1698,7 @@
         5,
         1344,
         768,
-        "Balanced — 22 frames",
+        "Strong — 39 frames",
         123456,
         "randomize",
         true,
@@ -1712,7 +1712,8 @@
         "",
         "Match Output",
         "178937a7-0b65-4964-b312-387ca0bdd733",
-        "Balanced - 0.6 MP"
+        "Balanced - 0.6 MP",
+        "Native Masked — exact continuation (Recommended)"
       ],
       "widgets_values_named": {
         "prompt_mode": "Auto",
@@ -1720,7 +1721,7 @@
         "chunk_seconds": 5,
         "width": 1344,
         "height": 768,
-        "continuity": "Balanced — 22 frames",
+        "continuity": "Strong — 39 frames",
         "base_seed": 123456,
         "control_after_generate": "randomize",
         "audio_continuity": true,
@@ -1734,7 +1735,8 @@
         "run_name": "",
         "reference_size": "Match Output",
         "project_id": "178937a7-0b65-4964-b312-387ca0bdd733",
-        "video_reference_size": "Balanced - 0.6 MP"
+        "video_reference_size": "Balanced - 0.6 MP",
+        "continuation_method": "Native Masked — exact continuation (Recommended)"
       },
       "color": "#232",
       "bgcolor": "#353"

--- a/masked_continuation.py
+++ b/masked_continuation.py
@@ -1,0 +1,374 @@
+"""Native MiniMax H3 target-latent continuation.
+
+Exact continuation uses ComfyUI Core's native per-token denoise-mask contract
+introduced by ComfyUI PR #15375. The previous generated AV latent is copied
+into the beginning of the next *target* latent; it is never represented as an
+ordinary H3 reference and therefore needs no Continuum RoPE/position-id rewrite.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import contextvars
+import hashlib
+from typing import Any
+
+import torch
+
+from .constants import AUDIO_LATENT_FPS, CONTINUITY_FRAMES, FPS, V2_CONTINUITY_AUTO
+from .continuation import clone_conditioning
+from .state import extract_av_streams, validate_state
+from .temporal import context_slots
+from .v2.motion import choose_context_frames, latent_motion_score
+
+
+CONTINUATION_NATIVE_MASKED = "Native Masked — exact continuation (Recommended)"
+CONTINUATION_GUIDE = "Guide / Motion Context"
+CONTINUATION_METHODS = (CONTINUATION_NATIVE_MASKED, CONTINUATION_GUIDE)
+NATIVE_MASK_CONTRACT_VERSION = 1
+NATIVE_MASK_CORE_MERGE_COMMIT = "ff6c8a8af144fc9e9e7bc436b1b202f9316848d8"
+
+_CURRENT_METHOD: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "h3_continuum_method", default=CONTINUATION_GUIDE
+)
+
+
+class NativeMaskedContinuationError(RuntimeError):
+    pass
+
+
+def validate_continuation_method(value: str) -> str:
+    value = str(value)
+    if value not in CONTINUATION_METHODS:
+        raise NativeMaskedContinuationError(
+            f"unknown continuation method: {value!r}; expected one of {CONTINUATION_METHODS!r}"
+        )
+    return value
+
+
+@contextmanager
+def continuation_method_scope(value: str):
+    """Set the invocation-local V3.4 continuation method.
+
+    ContextVar keeps concurrent/re-entrant prompt executions isolated while the
+    legacy V2/V3.3 public signatures remain byte-for-byte compatible.
+    """
+
+    method = validate_continuation_method(value)
+    token = _CURRENT_METHOD.set(method)
+    try:
+        yield method
+    finally:
+        _CURRENT_METHOD.reset(token)
+
+
+def current_continuation_method() -> str:
+    return validate_continuation_method(_CURRENT_METHOD.get())
+
+
+def native_mask_support_issues() -> list[str]:
+    """Return missing Core capabilities required by PR #15375."""
+
+    issues: list[str] = []
+    try:
+        import comfy.model_base as model_base
+    except Exception as exc:  # pragma: no cover - broken Comfy install
+        return [f"cannot import comfy.model_base: {exc}"]
+
+    base_cls = getattr(model_base, "MiniMaxH3", None)
+    if base_cls is None:
+        issues.append("comfy.model_base.MiniMaxH3 is missing")
+    else:
+        for name in (
+            "_denoise_mask_conds",
+            "_denoise_mask_values",
+            "_token_grid_masks",
+            "scale_latent_inpaint",
+        ):
+            if not callable(getattr(base_cls, name, None)):
+                issues.append(f"MiniMaxH3.{name} is missing")
+
+    try:
+        import comfy.nested_tensor
+
+        if not hasattr(comfy.nested_tensor, "NestedTensor"):
+            issues.append("comfy.nested_tensor.NestedTensor is missing")
+    except Exception as exc:  # pragma: no cover - broken Comfy install
+        issues.append(f"cannot import comfy.nested_tensor: {exc}")
+    return issues
+
+
+def require_native_mask_support() -> None:
+    issues = native_mask_support_issues()
+    if issues:
+        detail = "; ".join(issues)
+        raise NativeMaskedContinuationError(
+            "Native Masked continuation requires ComfyUI MiniMax-H3 per-token "
+            "denoise-mask support from ComfyUI PR #15375 "
+            f"(merge commit {NATIVE_MASK_CORE_MERGE_COMMIT}) or newer. "
+            f"Update ComfyUI, or select {CONTINUATION_GUIDE!r}. Missing capability: {detail}"
+        )
+
+
+def exact_audio_prefix_steps(context_frames: int) -> int:
+    """Map an exact 24-fps video prefix to the 40-Hz H3 audio grid."""
+
+    frames = int(context_frames)
+    numerator = frames * int(AUDIO_LATENT_FPS)
+    denominator = int(FPS)
+    if numerator % denominator:
+        raise NativeMaskedContinuationError(
+            f"{frames} video frames at {int(FPS)} fps do not land on an exact H3 "
+            f"audio-latent boundary at {int(AUDIO_LATENT_FPS)} Hz. Native generated-"
+            "audio continuation cannot silently round that boundary. Use 39-frame "
+            "continuity, disable generated Audio Continuity, or select Guide / Motion Context."
+        )
+    return numerator // denominator
+
+
+def validate_native_masked_request(
+    *,
+    method: str,
+    continuity: str,
+    audio_continuity: bool,
+    driving_audio_active: bool,
+    chunks: int,
+) -> None:
+    """Reject an impossible exact AV contract before any chunk is sampled.
+
+    Native video-only continuation can use every H3 video context profile. When
+    generated audio is also protected, the preserved prefix must end on both the
+    24-fps video grid and the 40-Hz audio grid. Auto resolves that requirement to
+    39 frames later from the accepted state; explicit 5/22-frame requests are
+    invalid and must never be discovered only after chunk 1 has finished.
+    """
+
+    method = validate_continuation_method(method)
+    if (
+        method != CONTINUATION_NATIVE_MASKED
+        or int(chunks) <= 1
+        or not bool(audio_continuity)
+        or bool(driving_audio_active)
+        or str(continuity) == V2_CONTINUITY_AUTO
+    ):
+        return
+    frames = CONTINUITY_FRAMES.get(str(continuity))
+    if frames is None:
+        raise NativeMaskedContinuationError(f"unknown continuity mode: {continuity!r}")
+    exact_audio_prefix_steps(int(frames))
+
+
+def choose_continuation_context_frames(
+    *,
+    method: str,
+    continuity: str,
+    state: dict[str, Any],
+    audio_continuity: bool,
+    driving_audio_active: bool,
+) -> tuple[int, float, str]:
+    """Resolve context without changing explicit user timing silently."""
+
+    method = validate_continuation_method(method)
+    state = validate_state(state)
+    if method == CONTINUATION_GUIDE:
+        return choose_context_frames(continuity, state)
+
+    carry_generated_audio = bool(audio_continuity) and not bool(driving_audio_active)
+    if carry_generated_audio and continuity == V2_CONTINUITY_AUTO:
+        capacity = int(state["capacity_frames"])
+        if capacity < 39:
+            raise NativeMaskedContinuationError(
+                "Native Masked generated-audio continuation needs the 39-frame exact "
+                f"AV boundary, but this state retains only {capacity} frames. Regenerate "
+                "the preceding chunk with normal 39-frame state capacity, disable Audio "
+                "Continuity, or select Guide / Motion Context."
+            )
+        score = latent_motion_score(state)
+        return 39, score, "native exact AV boundary (39 video frames = 65 audio steps)"
+
+    context_frames, score, reason = choose_context_frames(continuity, state)
+    if carry_generated_audio:
+        audio_steps = exact_audio_prefix_steps(context_frames)
+        reason = f"{reason}; exact AV boundary ({audio_steps} audio steps)"
+    return context_frames, score, reason
+
+
+def _validate_video_context(video_context: torch.Tensor, context_frames: int) -> int:
+    if not torch.is_tensor(video_context) or video_context.ndim != 5:
+        raise NativeMaskedContinuationError("video continuation context must be [1,24,T,H,W]")
+    if tuple(video_context.shape[:2]) != (1, 24):
+        raise NativeMaskedContinuationError("video continuation context must be [1,24,T,H,W]")
+    expected = context_slots(int(context_frames))
+    if int(video_context.shape[2]) != expected:
+        raise NativeMaskedContinuationError(
+            f"video context has latent T={int(video_context.shape[2])}; "
+            f"{int(context_frames)} frames require T={expected}"
+        )
+    return expected
+
+
+def _validate_audio_context(audio_context: torch.Tensor, context_frames: int) -> int:
+    if not torch.is_tensor(audio_context) or audio_context.ndim != 4:
+        raise NativeMaskedContinuationError("audio continuation context must be [1,32,2,T]")
+    if tuple(audio_context.shape[:3]) != (1, 32, 2):
+        raise NativeMaskedContinuationError("audio continuation context must be [1,32,2,T]")
+    expected = exact_audio_prefix_steps(int(context_frames))
+    if int(audio_context.shape[-1]) != expected:
+        raise NativeMaskedContinuationError(
+            f"audio context has latent T={int(audio_context.shape[-1])}; "
+            f"the exact {int(context_frames)}-frame AV boundary requires T={expected}"
+        )
+    return expected
+
+
+def apply_native_masked_continuation(
+    latent: dict[str, Any],
+    *,
+    video_context: torch.Tensor,
+    audio_context: torch.Tensor | None,
+    context_frames: int,
+) -> dict[str, Any]:
+    """Populate a fresh H3 target prefix and attach Core-native denoise masks.
+
+    The target tensors are intentionally modified in place: ``empty_h3_latent``
+    creates them uniquely for this chunk, so cloning the full target would only
+    double peak VRAM. Source context tensors are read-only and copied into the
+    target; no alias is retained.
+    """
+
+    require_native_mask_support()
+    if not isinstance(latent, dict) or "samples" not in latent:
+        raise NativeMaskedContinuationError("target latent must contain 'samples'")
+    video, audio = extract_av_streams(latent)
+    video_steps = _validate_video_context(video_context, context_frames)
+    if int(video.shape[2]) <= video_steps:
+        raise NativeMaskedContinuationError(
+            "target video latent contains no generatable region after the preserved prefix"
+        )
+    if tuple(video.shape[-2:]) != tuple(video_context.shape[-2:]):
+        raise NativeMaskedContinuationError(
+            "continuation video geometry does not match the new target latent"
+        )
+
+    # copy_ performs the required device/dtype conversion without allocating a
+    # full second target latent. It does not alias or mutate the CPU source state.
+    video[:, :, :video_steps].copy_(video_context)
+
+    # Core's generic MASK contract is float32. Keep it independent of the H3
+    # latent precision while retaining the target device and exact 0/1 values.
+    video_mask = torch.ones(
+        (1, 1, int(video.shape[2]), int(video.shape[3]), int(video.shape[4])),
+        device=video.device,
+        dtype=torch.float32,
+    )
+    video_mask[:, :, :video_steps] = 0
+    audio_mask = torch.ones(
+        (1, 1, int(audio.shape[2]), int(audio.shape[3])),
+        device=audio.device,
+        dtype=torch.float32,
+    )
+
+    if audio_context is not None:
+        audio_steps = _validate_audio_context(audio_context, context_frames)
+        if int(audio.shape[-1]) <= audio_steps:
+            raise NativeMaskedContinuationError(
+                "target audio latent contains no generatable region after the preserved prefix"
+            )
+        audio[..., :audio_steps].copy_(audio_context)
+        audio_mask[..., :audio_steps] = 0
+
+    try:
+        import comfy.nested_tensor
+    except Exception as exc:  # pragma: no cover
+        raise NativeMaskedContinuationError(
+            f"ComfyUI NestedTensor API unavailable: {exc}"
+        ) from exc
+
+    output = dict(latent)
+    output["noise_mask"] = comfy.nested_tensor.NestedTensor((video_mask, audio_mask))
+    return output
+
+
+def prepare_masked_conditioning(
+    conditioning,
+    *,
+    context_frames: int,
+    new_frame_count: int,
+):
+    """Remove target keyframes that compete with the protected prefix.
+
+    Ordinary Ref2VA image/video/audio references are preserved. A final-frame
+    keyframe remains valid because it lies outside the protected prefix. Driving
+    Audio is attached after this function and therefore remains the audio
+    authority when that mode is active.
+    """
+
+    output = clone_conditioning(conditioning)
+    for _, metadata in output:
+        kept = []
+        for raw in metadata.get("minimax_keyframes") or ():
+            keyframe = dict(raw)
+            frame_index = int(keyframe.get("resolved_frame_index", 0))
+            if 0 <= frame_index < int(context_frames):
+                continue
+            kept.append(keyframe)
+        if kept:
+            metadata["minimax_keyframes"] = kept
+        else:
+            metadata.pop("minimax_keyframes", None)
+        metadata["minimax_frame_count"] = int(new_frame_count)
+    return output
+
+
+def continuation_storage_plan(prompt_plan: dict[str, Any], method: str) -> dict[str, Any]:
+    """Salt only continuation-chunk fingerprints with backend semantics.
+
+    Chunk 1 has no continuation prefix, so its hash remains reusable across
+    Guide/Native method changes. Chunks 2+ carry a self-describing hash salt;
+    Run Storage can therefore reuse an unaffected first chunk from an older
+    revision while never accepting a Guide chunk as Native Masked (or a future
+    mask-contract version as v1).
+    """
+
+    method = validate_continuation_method(method)
+    if method == CONTINUATION_GUIDE:
+        return prompt_plan
+    result = dict(prompt_plan)
+    hashes = list(prompt_plan["hashes"])
+    for index in range(1, len(hashes)):
+        payload = (
+            f"{hashes[index]}\0continuation={method}\0"
+            f"native_mask_contract={NATIVE_MASK_CONTRACT_VERSION}"
+        ).encode("utf-8")
+        hashes[index] = (
+            f"h3c-native-mask-v{NATIVE_MASK_CONTRACT_VERSION}:"
+            + hashlib.sha256(payload).hexdigest()
+        )
+    result["hashes"] = hashes
+    return result
+
+
+def plan_continuation_contract(plan: dict[str, Any], method: str) -> dict[str, Any]:
+    result = dict(plan)
+    method = validate_continuation_method(method)
+    result["continuation_method"] = method
+    if method == CONTINUATION_NATIVE_MASKED:
+        result["native_mask_contract_version"] = NATIVE_MASK_CONTRACT_VERSION
+    return result
+
+
+def stored_plan_matches_method(plan: dict[str, Any], method: str, *, chunk_number: int) -> bool:
+    """Compatibility predicate for explicit Session reuse."""
+
+    method = validate_continuation_method(method)
+    if int(chunk_number) <= 1:
+        return True
+    stored = plan.get("continuation_method")
+    if method == CONTINUATION_GUIDE:
+        # Pre-feature sessions are the legacy Guide architecture.
+        return stored in (None, CONTINUATION_GUIDE)
+    return (
+        stored == CONTINUATION_NATIVE_MASKED
+        and int(plan.get("native_mask_contract_version", -1))
+        == NATIVE_MASK_CONTRACT_VERSION
+    )

--- a/reference.py
+++ b/reference.py
@@ -1,6 +1,6 @@
 """MiniMax H3 image-reference adapter for the V3 production sampler.
 
-This module only builds the public Core conditioning contract.  It does not
+This module only builds the public Core conditioning contract. It does not
 own model loading, sampling, VAE decoding, or any optimizer implementation.
 """
 
@@ -31,6 +31,13 @@ _PICTURE_TAG = re.compile(r"<Picture\s+(\d+)>")
 
 class ReferenceConditioningError(ValueError):
     pass
+
+
+@dataclass(frozen=True)
+class ReferenceImageBundle:
+    """Internal carrier used by the V3.4 facade for dynamic reference sockets."""
+
+    images: tuple[torch.Tensor, ...]
 
 
 @dataclass(frozen=True)
@@ -69,6 +76,13 @@ class ReferenceAssets:
         return result
 
 
+def bundle_reference_images(*images: torch.Tensor | None) -> ReferenceImageBundle | None:
+    """Compact dynamic V3.4 references without widening the legacy V3.3 API."""
+
+    active = tuple(image for image in images if image is not None)
+    return ReferenceImageBundle(active) if active else None
+
+
 def _canonical_hash(value: Any) -> str:
     payload = json.dumps(
         value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
@@ -86,7 +100,10 @@ def _tensor_hash(value: torch.Tensor) -> str:
 
 
 def _round_canvas(value: float) -> int:
-    return max(_CANVAS_MULTIPLE, int(round(value / _CANVAS_MULTIPLE)) * _CANVAS_MULTIPLE)
+    return max(
+        _CANVAS_MULTIPLE,
+        int(round(value / _CANVAS_MULTIPLE)) * _CANVAS_MULTIPLE,
+    )
 
 
 def _validate_image(name: str, image: torch.Tensor) -> torch.Tensor:
@@ -118,7 +135,10 @@ def _resize_reference(
         target_area = float(int(output_width) * int(output_height))
         scale = min(1.0, math.sqrt(target_area / float(source_width * source_height)))
     else:
-        scale = min(1.0, float(_MAX_IDENTITY_SHORT_EDGE) / min(source_width, source_height))
+        scale = min(
+            1.0,
+            float(_MAX_IDENTITY_SHORT_EDGE) / min(source_width, source_height),
+        )
     target_width = _round_canvas(source_width * scale)
     target_height = _round_canvas(source_height * scale)
     if target_width == source_width and target_height == source_height:
@@ -147,16 +167,34 @@ def prepare_reference_assets(
     output_width: int,
     output_height: int,
     size_mode: str,
-    reference_image_3: torch.Tensor | None = None,
+    reference_image_3: torch.Tensor | ReferenceImageBundle | None = None,
+    reference_image_4: torch.Tensor | None = None,
+    reference_image_5: torch.Tensor | None = None,
+    reference_image_6: torch.Tensor | None = None,
+    reference_image_7: torch.Tensor | None = None,
+    reference_image_8: torch.Tensor | None = None,
 ) -> ReferenceAssets | None:
     # Match Core's dynamic Reference inputs: bypassed or otherwise absent
     # sockets are ignored, then active images are numbered contiguously in
-    # connection order as Picture 1..N.
-    inputs = [
-        image
-        for image in (reference_image_1, reference_image_2, reference_image_3)
-        if image is not None
-    ]
+    # connection order as Picture 1..N. V3.4 may carry sockets 3..8 through
+    # an internal bundle so the legacy V3.3 production signature stays stable.
+    inputs: list[torch.Tensor] = []
+    for image in (
+        reference_image_1,
+        reference_image_2,
+        reference_image_3,
+        reference_image_4,
+        reference_image_5,
+        reference_image_6,
+        reference_image_7,
+        reference_image_8,
+    ):
+        if image is None:
+            continue
+        if isinstance(image, ReferenceImageBundle):
+            inputs.extend(image.images)
+        else:
+            inputs.append(image)
     if not inputs:
         return None
     images = tuple(
@@ -185,7 +223,9 @@ def prepare_reference_assets(
     )
 
 
-def encode_reference_latents(video_vae: Any, assets: ReferenceAssets) -> ReferenceAssets:
+def encode_reference_latents(
+    video_vae: Any, assets: ReferenceAssets
+) -> ReferenceAssets:
     if all(latent is not None for latent in assets.latents):
         return assets
     latents = tuple(video_vae.encode(image) for image in assets.images)

--- a/temporal.py
+++ b/temporal.py
@@ -120,6 +120,17 @@ def make_extension_shape(context_frames:int, extend_seconds:float)->ExtensionSha
     if net<1: raise RuntimeError("computed continuation contains no new frames")
     return ExtensionShape(context_frames,requested_new,total,net,video_latent_t(total),audio_latent_t(total))
 
+def make_extension_shape_at_least(context_frames:int,requested_new_frames:int)->ExtensionShape:
+    """Create a native H3 continuation that never undershoots requested new frames."""
+    context_frames=int(context_frames)
+    context_slots(context_frames)
+    requested_new=max(1,int(requested_new_frames))
+    total=align_frame_count_up(context_frames+requested_new)
+    net=total-context_frames
+    if net<requested_new:
+        raise RuntimeError("computed continuation undershot requested new frame count")
+    return ExtensionShape(context_frames,requested_new,total,net,video_latent_t(total),audio_latent_t(total))
+
 def largest_context_capacity(frame_count:int)->int:
     available=int(frame_count)
     for capacity in (39,22,5):
@@ -135,6 +146,8 @@ def run_temporal_self_test()->None:
     shape=make_extension_shape(22,5.0)
     assert (shape.total_frames,shape.net_new_frames)==(141,119)
     assert (shape.video_latent_t,shape.audio_latent_t)==(42,235)
+    minimum_shape=make_extension_shape_at_least(22,161)
+    assert (minimum_shape.total_frames,minimum_shape.net_new_frames)==(192,170)
     window=make_av_context_window(141,235,22)
     assert (window.video_start_slot,window.video_stop_slot)==(35,42)
     assert (window.audio_start_tick,window.audio_stop_tick)==(198,235)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -6,7 +6,7 @@ from ComfyUI_H3_Continuum_Join.compatibility import (
 )
 
 
-def test_signature_contract_accepts_native_packed_layout_signature():
+def test_signature_contract_accepts_legacy_packed_layout_signature():
     def native(
         self,
         text_len,
@@ -23,7 +23,27 @@ def test_signature_contract_accepts_native_packed_layout_signature():
     assert _missing_callable_parameters(
         native,
         positional=("text_len", "latent_t", "latent_h", "latent_w", "audio_t"),
-        keywords=("keyframes", "refs", "frame_count"),
+        keywords=("keyframes", "refs"),
+    ) == []
+
+
+def test_signature_contract_accepts_current_packed_layout_without_frame_count():
+    def native(
+        self,
+        text_len,
+        latent_t,
+        latent_h,
+        latent_w,
+        audio_t,
+        keyframes=None,
+        refs=None,
+    ):
+        pass
+
+    assert _missing_callable_parameters(
+        native,
+        positional=("text_len", "latent_t", "latent_h", "latent_w", "audio_t"),
+        keywords=("keyframes", "refs"),
     ) == []
 
 
@@ -38,7 +58,7 @@ def test_signature_contract_accepts_sol_attn_style_forwarding_wrapper():
     assert _missing_callable_parameters(
         sol_wrapper,
         positional=("text_len", "latent_t", "latent_h", "latent_w", "audio_t"),
-        keywords=("keyframes", "refs", "frame_count"),
+        keywords=("keyframes", "refs"),
     ) == []
 
 
@@ -49,8 +69,8 @@ def test_signature_contract_still_fails_closed_for_real_keyword_removal():
     assert _missing_callable_parameters(
         incompatible,
         positional=("text_len", "latent_t", "latent_h", "latent_w", "audio_t"),
-        keywords=("keyframes", "refs", "frame_count"),
-    ) == ["keyframes", "refs", "frame_count"]
+        keywords=("keyframes", "refs"),
+    ) == ["keyframes", "refs"]
 
 
 def test_accelerator_summary_reads_modelpatcher_wrappers_and_transformer_markers():

--- a/tests/test_conditioning_modes.py
+++ b/tests/test_conditioning_modes.py
@@ -13,6 +13,9 @@ from ComfyUI_H3_Continuum_Join.conditioning import (
         (False, True, False, "last_only"),
         (True, True, False, "fl2va"),
         (False, False, True, "reference"),
+        (True, False, True, "i2va"),
+        (False, True, True, "last_only"),
+        (True, True, True, "fl2va"),
     ],
 )
 def test_conditioning_mode_matrix(
@@ -25,13 +28,19 @@ def test_conditioning_mode_matrix(
     ) == expected
 
 
-@pytest.mark.parametrize(
-    ("has_first", "has_last"),
-    [(True, False), (False, True), (True, True)],
-)
-def test_reference_takes_precedence_over_first_or_last_frame(has_first, has_last):
+def test_references_augment_keyframe_mode_instead_of_overriding_it():
     assert conditioning_mode_from_presence(
-        has_first=has_first,
-        has_last=has_last,
+        has_first=True,
+        has_last=False,
         has_reference=True,
-    ) == "reference"
+    ) == "i2va"
+    assert conditioning_mode_from_presence(
+        has_first=False,
+        has_last=True,
+        has_reference=True,
+    ) == "last_only"
+    assert conditioning_mode_from_presence(
+        has_first=True,
+        has_last=True,
+        has_reference=True,
+    ) == "fl2va"

--- a/tests/test_exact_duration_tail.py
+++ b/tests/test_exact_duration_tail.py
@@ -1,0 +1,220 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from ComfyUI_H3_Continuum_Join.constants import (
+    DIAGNOSTICS_BASIC,
+    PROMPT_MODE_FIXED,
+    V2_CONTINUITY_OPTIONS,
+)
+from ComfyUI_H3_Continuum_Join.temporal import audio_latent_t, video_latent_t
+from ComfyUI_H3_Continuum_Join.v2 import sequence
+from ComfyUI_H3_Continuum_Join.v2.h3_builder import IdentityAssets
+from ComfyUI_H3_Continuum_Join.v2.prompts import make_prompt_plan
+from ComfyUI_H3_Continuum_Join.v3.plan import (
+    ASSEMBLY_PLAN_MAGIC,
+    AssemblyPlanError,
+    validate_assembly_plan,
+)
+
+
+class Nested:
+    def __init__(self, parts):
+        self.parts = list(parts)
+
+    def unbind(self):
+        return self.parts
+
+
+def _latent(width, height, frames):
+    return {
+        "samples": Nested(
+            (
+                torch.zeros(
+                    1,
+                    24,
+                    video_latent_t(frames),
+                    height // 16,
+                    width // 16,
+                ),
+                torch.zeros(1, 32, 2, audio_latent_t(frames)),
+            )
+        )
+    }
+
+
+class FakeClip:
+    def tokenize(self, prompt, images):
+        return prompt
+
+    def encode_from_tokens_scheduled(self, tokens):
+        return [[torch.zeros(1, 1, 2), {}]]
+
+
+def _fake_model():
+    return SimpleNamespace(
+        model=SimpleNamespace(diffusion_model=SimpleNamespace()),
+        model_options={},
+        wrappers={},
+        model_dtype=lambda: torch.bfloat16,
+        model_size=lambda: 0,
+    )
+
+
+def test_final_chunk_rounds_up_without_changing_intermediate_nearest_grid(monkeypatch):
+    width, height = 96, 64
+    assets = IdentityAssets(None, None, None, None, "none")
+    model = _fake_model()
+
+    monkeypatch.setattr(sequence, "check_comfy_h3_runtime", lambda: [])
+    monkeypatch.setattr(sequence, "prepare_identity_assets", lambda *a, **k: assets)
+    monkeypatch.setattr(sequence, "encode_identity_latents", lambda *a, **k: assets)
+    monkeypatch.setattr(sequence, "empty_h3_latent", _latent)
+    monkeypatch.setattr(sequence, "accelerator_summary", lambda _model: "accelerators")
+    monkeypatch.setattr(
+        sequence,
+        "clone_model_for_chunk",
+        lambda model, **kwargs: model,
+    )
+    monkeypatch.setattr(
+        sequence,
+        "sample_chunk",
+        lambda **kwargs: kwargs["latent"],
+    )
+
+    prompt_plan = make_prompt_plan(
+        mode=PROMPT_MODE_FIXED,
+        script="continuous motion",
+        chunks=3,
+        chunk_seconds=7.0,
+    )
+    entries, _last_state, _session, _report = sequence.run_sequence(
+        model=model,
+        clip=FakeClip(),
+        video_vae=object(),
+        audio_vae=None,
+        sampler=object(),
+        sigmas=torch.tensor([1.0, 0.0]),
+        first_frame=None,
+        last_frame=None,
+        prompt_plan=prompt_plan,
+        width=width,
+        height=height,
+        continuity=V2_CONTINUITY_OPTIONS[1],
+        base_seed=42,
+        audio_continuity=True,
+        exact_total_duration=False,
+        diagnostics_mode=DIAGNOSTICS_BASIC,
+        reroll_from_chunk=0,
+        reroll_nonce=0,
+        strict_compatibility=True,
+        debug=False,
+        latent_only=True,
+    )
+
+    plans = [entry["plan"] for entry in entries]
+    assert [plan["total_frames"] for plan in plans] == [175, 175, 209]
+    assert [plan["net_frames"] for plan in plans] == [175, 153, 187]
+    assert sum(plan["net_frames"] for plan in plans) == 515
+    assert sum(plan["net_frames"] for plan in plans) >= 3 * 7 * 24
+
+
+def test_short_cached_final_chunk_is_not_reused(monkeypatch):
+    monkeypatch.setattr(sequence, "validate_session", lambda session: session)
+    monkeypatch.setattr(sequence, "validate_chunk_entry", lambda entry: entry)
+
+    session = {
+        "width": 96,
+        "height": 64,
+        "chunk_seconds": 7.0,
+        "identity_hash": "none",
+        "chunks": [
+            {"prompt_hash": "p1", "plan": {"net_frames": 175}},
+            {"prompt_hash": "p2", "plan": {"net_frames": 153}},
+        ],
+    }
+
+    preserved, notes = sequence._preserved_prefix(
+        session=session,
+        prompt_hashes=["p1", "p2"],
+        chunks=2,
+        reroll_from_chunk=0,
+        width=96,
+        height=64,
+        chunk_seconds=7.0,
+        identity_hash="none",
+    )
+
+    assert len(preserved) == 1
+    assert any("retained 328 frames for 336-frame target" in note for note in notes)
+
+
+def test_cached_final_chunk_at_or_above_target_remains_reusable(monkeypatch):
+    monkeypatch.setattr(sequence, "validate_session", lambda session: session)
+    monkeypatch.setattr(sequence, "validate_chunk_entry", lambda entry: entry)
+
+    session = {
+        "width": 96,
+        "height": 64,
+        "chunk_seconds": 7.0,
+        "identity_hash": "none",
+        "chunks": [
+            {"prompt_hash": "p1", "plan": {"net_frames": 175}},
+            {"prompt_hash": "p2", "plan": {"net_frames": 170}},
+        ],
+    }
+
+    preserved, _notes = sequence._preserved_prefix(
+        session=session,
+        prompt_hashes=["p1", "p2"],
+        chunks=2,
+        reroll_from_chunk=0,
+        width=96,
+        height=64,
+        chunk_seconds=7.0,
+        identity_hash="none",
+    )
+
+    assert len(preserved) == 2
+
+
+def test_v3_assembly_plan_rejects_legacy_under_length_sequence():
+    plan = {
+        "magic": ASSEMBLY_PLAN_MAGIC,
+        "schema_version": 1,
+        "fps": 24,
+        "width": 96,
+        "height": 64,
+        "chunk_seconds": 7.0,
+        "target_frames": 336,
+        "preserve_final_frame": False,
+        "chunks": [
+            {
+                "sequence_index": 1,
+                "chunk_index": 1,
+                "total_frames": 175,
+                "trim_frames": 0,
+                "net_frames": 175,
+                "context_frames": 5,
+                "expected_video_latent_t": 52,
+                "expected_audio_latent_t": 292,
+            },
+            {
+                "sequence_index": 2,
+                "chunk_index": 2,
+                "total_frames": 175,
+                "trim_frames": 22,
+                "net_frames": 153,
+                "context_frames": 22,
+                "expected_video_latent_t": 52,
+                "expected_audio_latent_t": 292,
+            },
+        ],
+    }
+
+    with pytest.raises(
+        AssemblyPlanError,
+        match="retains 328 frames for a 336-frame target",
+    ):
+        validate_assembly_plan(plan)

--- a/tests/test_masked_continuation.py
+++ b/tests/test_masked_continuation.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+from ComfyUI_H3_Continuum_Join.constants import (
+    PROMPT_MODE_FIXED,
+    STATE_MAGIC,
+    V2_CONTINUITY_AUTO,
+    V2_CONTINUITY_OPTIONS,
+)
+from ComfyUI_H3_Continuum_Join.masked_continuation import (
+    CONTINUATION_GUIDE,
+    CONTINUATION_NATIVE_MASKED,
+    NATIVE_MASK_CONTRACT_VERSION,
+    NativeMaskedContinuationError,
+    apply_native_masked_continuation,
+    choose_continuation_context_frames,
+    continuation_method_scope,
+    continuation_storage_plan,
+    current_continuation_method,
+    exact_audio_prefix_steps,
+    plan_continuation_contract,
+    prepare_masked_conditioning,
+    require_native_mask_support,
+    stored_plan_matches_method,
+)
+from ComfyUI_H3_Continuum_Join.temporal import audio_latent_t, context_slots
+from ComfyUI_H3_Continuum_Join.v2.prompts import make_prompt_plan
+from ComfyUI_H3_Continuum_Join.version import STATE_SCHEMA_VERSION
+
+
+class Nested:
+    def __init__(self, parts):
+        self.parts = list(parts)
+
+    def unbind(self):
+        return self.parts
+
+
+def _install_fake_nested_tensor(monkeypatch):
+    comfy = sys.modules.get("comfy")
+    if comfy is None:
+        comfy = ModuleType("comfy")
+        comfy.__path__ = []
+        monkeypatch.setitem(sys.modules, "comfy", comfy)
+    nested = ModuleType("comfy.nested_tensor")
+    nested.NestedTensor = Nested
+    monkeypatch.setitem(sys.modules, "comfy.nested_tensor", nested)
+    monkeypatch.setattr(comfy, "nested_tensor", nested, raising=False)
+
+
+def _state(capacity=39):
+    return {
+        "magic": STATE_MAGIC,
+        "schema_version": STATE_SCHEMA_VERSION,
+        "clip_index": 1,
+        "source_frame_count": 124,
+        "capacity_frames": capacity,
+        "width": 32,
+        "height": 32,
+        "video_tail": torch.zeros(1, 24, context_slots(capacity), 2, 2),
+        "audio_tail": torch.zeros(1, 32, 2, audio_latent_t(capacity)),
+        "audio_overhang": 0.0,
+        "source_mode": "latent_direct",
+    }
+
+
+def _target(*, dtype=torch.float32):
+    video = torch.full((1, 24, 20, 2, 2), -3.0, dtype=dtype)
+    audio = torch.full((1, 32, 2, 100), -4.0, dtype=dtype)
+    return {"samples": Nested((video, audio))}
+
+
+@pytest.mark.parametrize("frames,expected", [(39, 65), (90, 150), (141, 235)])
+def test_exact_av_context_mapping(frames, expected):
+    assert exact_audio_prefix_steps(frames) == expected
+
+
+@pytest.mark.parametrize("frames", [5, 22])
+def test_non_exact_generated_audio_context_is_rejected(frames):
+    with pytest.raises(NativeMaskedContinuationError, match="cannot silently round"):
+        exact_audio_prefix_steps(frames)
+
+
+def test_native_auto_generated_audio_resolves_to_exact_39_frame_boundary():
+    frames, _score, reason = choose_continuation_context_frames(
+        method=CONTINUATION_NATIVE_MASKED,
+        continuity=V2_CONTINUITY_AUTO,
+        state=_state(),
+        audio_continuity=True,
+        driving_audio_active=False,
+    )
+    assert frames == 39
+    assert "65 audio steps" in reason
+
+
+@pytest.mark.parametrize(
+    "continuity,frames",
+    [
+        (V2_CONTINUITY_OPTIONS[1], 22),
+        (V2_CONTINUITY_OPTIONS[2], 5),
+        (V2_CONTINUITY_OPTIONS[3], 39),
+    ],
+)
+def test_native_video_only_keeps_existing_valid_context_profiles(continuity, frames):
+    selected, _score, _reason = choose_continuation_context_frames(
+        method=CONTINUATION_NATIVE_MASKED,
+        continuity=continuity,
+        state=_state(),
+        audio_continuity=False,
+        driving_audio_active=False,
+    )
+    assert selected == frames
+
+
+def test_native_driving_audio_does_not_force_generated_audio_boundary():
+    frames, _score, _reason = choose_continuation_context_frames(
+        method=CONTINUATION_NATIVE_MASKED,
+        continuity=V2_CONTINUITY_OPTIONS[1],
+        state=_state(),
+        audio_continuity=True,
+        driving_audio_active=True,
+    )
+    assert frames == 22
+
+
+def test_native_mask_reports_precise_old_core_compatibility_error(monkeypatch):
+    import ComfyUI_H3_Continuum_Join.masked_continuation as masked
+
+    monkeypatch.setattr(
+        masked,
+        "native_mask_support_issues",
+        lambda: ["MiniMaxH3._denoise_mask_conds is missing"],
+    )
+    with pytest.raises(NativeMaskedContinuationError) as exc_info:
+        require_native_mask_support()
+    message = str(exc_info.value)
+    assert "PR #15375" in message
+    assert "ff6c8a8af144fc9e9e7bc436b1b202f9316848d8" in message
+    assert "Guide / Motion Context" in message
+    assert "_denoise_mask_conds" in message
+
+
+def test_native_mask_copies_exact_video_and_audio_prefix_and_preserves_source(monkeypatch):
+    import ComfyUI_H3_Continuum_Join.masked_continuation as masked
+
+    _install_fake_nested_tensor(monkeypatch)
+    monkeypatch.setattr(masked, "require_native_mask_support", lambda: None)
+    video_context = torch.arange(1 * 24 * 12 * 2 * 2, dtype=torch.float32).reshape(
+        1, 24, 12, 2, 2
+    )
+    audio_context = torch.arange(1 * 32 * 2 * 65, dtype=torch.float32).reshape(
+        1, 32, 2, 65
+    )
+    video_before = video_context.clone()
+    audio_before = audio_context.clone()
+    latent = _target(dtype=torch.float16)
+
+    output = apply_native_masked_continuation(
+        latent,
+        video_context=video_context,
+        audio_context=audio_context,
+        context_frames=39,
+    )
+    video, audio = output["samples"].unbind()
+    video_mask, audio_mask = output["noise_mask"].unbind()
+
+    assert video.dtype == torch.float16 and audio.dtype == torch.float16
+    assert torch.equal(video[:, :, :12], video_context.to(torch.float16))
+    assert torch.equal(audio[..., :65], audio_context.to(torch.float16))
+    assert torch.all(video_mask[:, :, :12] == 0)
+    assert torch.all(video_mask[:, :, 12:] == 1)
+    assert torch.all(audio_mask[..., :65] == 0)
+    assert torch.all(audio_mask[..., 65:] == 1)
+    assert video_mask.shape == (1, 1, 20, 2, 2)
+    assert audio_mask.shape == (1, 1, 2, 100)
+    assert video_mask.dtype == torch.float32
+    assert audio_mask.dtype == torch.float32
+    assert video_mask.device == video.device
+    assert audio_mask.device == audio.device
+    assert torch.equal(video_context, video_before)
+    assert torch.equal(audio_context, audio_before)
+
+
+def test_native_mask_rejects_video_target_without_generatable_region(monkeypatch):
+    import ComfyUI_H3_Continuum_Join.masked_continuation as masked
+
+    _install_fake_nested_tensor(monkeypatch)
+    monkeypatch.setattr(masked, "require_native_mask_support", lambda: None)
+    latent = {
+        "samples": Nested(
+            (
+                torch.zeros(1, 24, 12, 2, 2),
+                torch.zeros(1, 32, 2, 100),
+            )
+        )
+    }
+
+    with pytest.raises(NativeMaskedContinuationError, match="video latent contains no generatable region"):
+        apply_native_masked_continuation(
+            latent,
+            video_context=torch.zeros(1, 24, 12, 2, 2),
+            audio_context=None,
+            context_frames=39,
+        )
+
+
+def test_native_mask_rejects_audio_target_without_generatable_region(monkeypatch):
+    import ComfyUI_H3_Continuum_Join.masked_continuation as masked
+
+    _install_fake_nested_tensor(monkeypatch)
+    monkeypatch.setattr(masked, "require_native_mask_support", lambda: None)
+    latent = {
+        "samples": Nested(
+            (
+                torch.zeros(1, 24, 20, 2, 2),
+                torch.zeros(1, 32, 2, 65),
+            )
+        )
+    }
+
+    with pytest.raises(NativeMaskedContinuationError, match="audio latent contains no generatable region"):
+        apply_native_masked_continuation(
+            latent,
+            video_context=torch.zeros(1, 24, 12, 2, 2),
+            audio_context=torch.zeros(1, 32, 2, 65),
+            context_frames=39,
+        )
+
+
+def test_native_mask_rejects_spatial_geometry_mismatch(monkeypatch):
+    import ComfyUI_H3_Continuum_Join.masked_continuation as masked
+
+    _install_fake_nested_tensor(monkeypatch)
+    monkeypatch.setattr(masked, "require_native_mask_support", lambda: None)
+
+    with pytest.raises(NativeMaskedContinuationError, match="geometry does not match"):
+        apply_native_masked_continuation(
+            _target(),
+            video_context=torch.zeros(1, 24, 12, 4, 4),
+            audio_context=None,
+            context_frames=39,
+        )
+
+
+def test_video_only_native_mask_leaves_entire_audio_stream_generatable(monkeypatch):
+    import ComfyUI_H3_Continuum_Join.masked_continuation as masked
+
+    _install_fake_nested_tensor(monkeypatch)
+    monkeypatch.setattr(masked, "require_native_mask_support", lambda: None)
+    video_context = torch.ones(1, 24, context_slots(22), 2, 2)
+    latent = _target()
+
+    output = apply_native_masked_continuation(
+        latent,
+        video_context=video_context,
+        audio_context=None,
+        context_frames=22,
+    )
+    video_mask, audio_mask = output["noise_mask"].unbind()
+    assert torch.all(video_mask[:, :, : context_slots(22)] == 0)
+    assert torch.all(audio_mask == 1)
+
+
+def test_masked_conditioning_removes_competing_prefix_keyframes_and_keeps_last_and_refs():
+    refs = [
+        {"kind": "image", "name": f"ref-{index}"}
+        for index in range(8)
+    ] + [
+        {"kind": "video", "name": "video-reference"},
+        {"kind": "audio", "name": "standalone-reference-audio"},
+    ]
+    conditioning = [[
+        torch.zeros(1, 1, 2),
+        {
+            "minimax_frame_count": 141,
+            "minimax_keyframes": [
+                {"resolved_frame_index": 0, "latent": "first"},
+                {"resolved_frame_index": 10, "latent": "inside-prefix"},
+                {"resolved_frame_index": 140, "latent": "last"},
+            ],
+            "minimax_refs": refs,
+        },
+    ]]
+
+    output = prepare_masked_conditioning(
+        conditioning,
+        context_frames=39,
+        new_frame_count=141,
+    )
+    metadata = output[0][1]
+    assert metadata["minimax_keyframes"] == [
+        {"resolved_frame_index": 140, "latent": "last"}
+    ]
+    assert metadata["minimax_refs"] == refs
+    assert metadata["minimax_refs"] is refs  # shallow metadata clone keeps read-only ref list
+    assert conditioning[0][1]["minimax_keyframes"][0]["latent"] == "first"
+
+
+def test_masked_conditioning_keeps_keyframe_at_first_unprotected_frame():
+    conditioning = [[
+        torch.zeros(1, 1, 2),
+        {"minimax_keyframes": [{"resolved_frame_index": 39, "latent": "guide"}]},
+    ]]
+    output = prepare_masked_conditioning(
+        conditioning,
+        context_frames=39,
+        new_frame_count=141,
+    )
+    assert output[0][1]["minimax_keyframes"][0]["resolved_frame_index"] == 39
+
+
+def test_run_storage_fingerprint_salts_only_continuation_chunks():
+    plan = make_prompt_plan(
+        mode=PROMPT_MODE_FIXED,
+        script="continuous shot",
+        chunks=3,
+        chunk_seconds=5.0,
+    )
+    native = continuation_storage_plan(plan, CONTINUATION_NATIVE_MASKED)
+    guide = continuation_storage_plan(plan, CONTINUATION_GUIDE)
+    assert guide is plan
+    assert native["hashes"][0] == plan["hashes"][0]
+    assert native["hashes"][1:] != plan["hashes"][1:]
+    assert all(value.startswith("h3c-native-mask-v1:") for value in native["hashes"][1:])
+
+
+def test_stored_chunk_contract_rejects_legacy_guide_chunk_for_native_but_keeps_chunk_one():
+    legacy = {"continuation": True}
+    native = plan_continuation_contract(legacy, CONTINUATION_NATIVE_MASKED)
+    assert stored_plan_matches_method(legacy, CONTINUATION_NATIVE_MASKED, chunk_number=1)
+    assert not stored_plan_matches_method(legacy, CONTINUATION_NATIVE_MASKED, chunk_number=2)
+    assert stored_plan_matches_method(legacy, CONTINUATION_GUIDE, chunk_number=2)
+    assert stored_plan_matches_method(native, CONTINUATION_NATIVE_MASKED, chunk_number=2)
+    assert native["native_mask_contract_version"] == NATIVE_MASK_CONTRACT_VERSION
+
+
+def test_continuation_method_scope_is_reentrant_and_does_not_leak_state():
+    assert current_continuation_method() == CONTINUATION_GUIDE
+    with continuation_method_scope(CONTINUATION_NATIVE_MASKED):
+        assert current_continuation_method() == CONTINUATION_NATIVE_MASKED
+        with continuation_method_scope(CONTINUATION_GUIDE):
+            assert current_continuation_method() == CONTINUATION_GUIDE
+        assert current_continuation_method() == CONTINUATION_NATIVE_MASKED
+    assert current_continuation_method() == CONTINUATION_GUIDE

--- a/tests/test_model_patch.py
+++ b/tests/test_model_patch.py
@@ -105,6 +105,40 @@ def test_apply_model_wrapper_repairs_keyframes_with_audio_reference_without_cont
     assert result["cond_audio_latents"] == [audio]
 
 
+def test_native_masked_ordinary_refs_never_invoke_continuum_layout_rewrite(monkeypatch):
+    import ComfyUI_H3_Continuum_Join.model_patch as model_patch
+
+    first = torch.zeros(1, 24, 1, 1, 1)
+    reference = torch.ones(1, 24, 1, 1, 1)
+    payload = {
+        "keyframes": [{"resolved_frame_index": 4, "latent": first}],
+        "refs": [
+            {
+                "kind": "image",
+                "latent_t": 1,
+                "latent_h": 1,
+                "latent_w": 1,
+                "latent": reference,
+            }
+        ],
+        "layout": SimpleNamespace(position_ids=torch.arange(9).reshape(3, 3).clone()),
+    }
+    position_ids_object = payload["layout"].position_ids
+    position_ids_before = position_ids_object.clone()
+
+    def forbidden_layout_rewrite(*args, **kwargs):
+        raise AssertionError("Native Masked ordinary conditioning must not rewrite H3 position_ids")
+
+    monkeypatch.setattr(model_patch, "patch_layout_in_place", forbidden_layout_rewrite)
+    result = model_patch._wrapper_factory(strict=True, debug=False)(
+        Executor(), torch.zeros(1), minimax_payload=payload
+    )
+
+    assert result["cond_video_latents"] == [first, reference]
+    assert torch.equal(result["layout"].position_ids, position_ids_before)
+    assert result["layout"].position_ids is position_ids_object
+
+
 def test_apply_model_wrapper_fails_when_actual_topology_changes():
     video = torch.zeros(1, 24, 1, 1, 1)
     audio = torch.zeros(1, 32, 2, 1)

--- a/tests/test_native_masked_preflight.py
+++ b/tests/test_native_masked_preflight.py
@@ -1,0 +1,48 @@
+import pytest
+
+from ComfyUI_H3_Continuum_Join.constants import V2_CONTINUITY_AUTO, V2_CONTINUITY_OPTIONS
+from ComfyUI_H3_Continuum_Join.masked_continuation import (
+    CONTINUATION_GUIDE,
+    CONTINUATION_NATIVE_MASKED,
+    NativeMaskedContinuationError,
+    validate_native_masked_request,
+)
+
+
+@pytest.mark.parametrize("continuity", [V2_CONTINUITY_OPTIONS[1], V2_CONTINUITY_OPTIONS[2]])
+def test_native_generated_audio_rejects_non_shared_av_profiles(continuity):
+    with pytest.raises(NativeMaskedContinuationError, match="do not land on an exact H3"):
+        validate_native_masked_request(
+            method=CONTINUATION_NATIVE_MASKED,
+            continuity=continuity,
+            audio_continuity=True,
+            driving_audio_active=False,
+            chunks=2,
+        )
+
+
+@pytest.mark.parametrize(
+    "method,continuity,audio_continuity,driving_audio_active,chunks",
+    [
+        (CONTINUATION_NATIVE_MASKED, V2_CONTINUITY_OPTIONS[3], True, False, 2),
+        (CONTINUATION_NATIVE_MASKED, V2_CONTINUITY_AUTO, True, False, 2),
+        (CONTINUATION_NATIVE_MASKED, V2_CONTINUITY_OPTIONS[1], False, False, 2),
+        (CONTINUATION_NATIVE_MASKED, V2_CONTINUITY_OPTIONS[1], True, True, 2),
+        (CONTINUATION_NATIVE_MASKED, V2_CONTINUITY_OPTIONS[1], True, False, 1),
+        (CONTINUATION_GUIDE, V2_CONTINUITY_OPTIONS[1], True, False, 2),
+    ],
+)
+def test_native_av_preflight_preserves_valid_nonconflicting_modes(
+    method,
+    continuity,
+    audio_continuity,
+    driving_audio_active,
+    chunks,
+):
+    validate_native_masked_request(
+        method=method,
+        continuity=continuity,
+        audio_continuity=audio_continuity,
+        driving_audio_active=driving_audio_active,
+        chunks=chunks,
+    )

--- a/tests/test_native_masked_sequence.py
+++ b/tests/test_native_masked_sequence.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from ComfyUI_H3_Continuum_Join.constants import (
+    CONTINUUM_INTEROP_KEY,
+    DIAGNOSTICS_BASIC,
+    PROMPT_MODE_FIXED,
+    V2_CONTINUITY_AUTO,
+    V2_CONTINUITY_OPTIONS,
+)
+from ComfyUI_H3_Continuum_Join.masked_continuation import (
+    CONTINUATION_GUIDE,
+    CONTINUATION_NATIVE_MASKED,
+    continuation_method_scope,
+)
+from ComfyUI_H3_Continuum_Join.temporal import audio_latent_t, video_latent_t
+from ComfyUI_H3_Continuum_Join.v2.h3_builder import IdentityAssets
+from ComfyUI_H3_Continuum_Join.v2.prompts import make_prompt_plan
+from ComfyUI_H3_Continuum_Join.v2 import sequence
+
+
+class Nested:
+    def __init__(self, parts):
+        self.parts = list(parts)
+
+    def unbind(self):
+        return self.parts
+
+
+def _latent(width, height, frames):
+    return {
+        "samples": Nested(
+            (
+                torch.zeros(1, 24, video_latent_t(frames), height // 16, width // 16),
+                torch.zeros(1, 32, 2, audio_latent_t(frames)),
+            )
+        )
+    }
+
+
+class FakeClip:
+    def tokenize(self, prompt, images):
+        return prompt
+
+    def encode_from_tokens_scheduled(self, tokens):
+        return [[torch.zeros(1, 1, 2), {}]]
+
+
+def _install_common_runtime(monkeypatch, events):
+    width, height = 96, 64
+    model = SimpleNamespace(
+        model=SimpleNamespace(diffusion_model=SimpleNamespace()),
+        model_options={},
+        wrappers={},
+        model_dtype=lambda: torch.bfloat16,
+        model_size=lambda: 0,
+    )
+    assets = IdentityAssets(None, None, None, None, "none")
+    monkeypatch.setattr(sequence, "check_comfy_h3_runtime", lambda: [])
+    monkeypatch.setattr(sequence, "require_native_mask_support", lambda: None)
+    monkeypatch.setattr(sequence, "prepare_identity_assets", lambda *a, **k: assets)
+    monkeypatch.setattr(sequence, "encode_identity_latents", lambda *a, **k: assets)
+    monkeypatch.setattr(sequence, "empty_h3_latent", _latent)
+    monkeypatch.setattr(sequence, "accelerator_summary", lambda model: "accelerators")
+
+    def clone_model_for_chunk(model, *, strict, debug, chunk_index, context_frames):
+        options = dict(model.model_options)
+        transformer = dict(options.get("transformer_options") or {})
+        if context_frames is not None:
+            transformer[CONTINUUM_INTEROP_KEY] = {
+                "api": 1,
+                "active": True,
+                "min_actual_prefix_steps": 2,
+            }
+        options["transformer_options"] = transformer
+        events.append(("clone", chunk_index, context_frames, transformer.get(CONTINUUM_INTEROP_KEY)))
+        return SimpleNamespace(
+            model=model.model,
+            model_options=options,
+            wrappers=model.wrappers,
+            model_dtype=model.model_dtype,
+            model_size=model.model_size,
+        )
+
+    monkeypatch.setattr(sequence, "clone_model_for_chunk", clone_model_for_chunk)
+
+    sample_number = 0
+
+    def sample_chunk(**kwargs):
+        nonlocal sample_number
+        sample_number += 1
+        video, audio = kwargs["latent"]["samples"].unbind()
+        events.append(
+            (
+                "sample",
+                sample_number,
+                "noise_mask" in kwargs["latent"],
+                kwargs["model"].model_options["transformer_options"].get(CONTINUUM_INTEROP_KEY),
+            )
+        )
+        # Make the accepted chunk latent distinguishable so chunk N+1 can prove
+        # it selected the immediately preceding accepted latent, including after
+        # CPU session/state conversion.
+        video.fill_(float(sample_number))
+        audio.fill_(float(sample_number * 10))
+        return kwargs["latent"]
+
+    monkeypatch.setattr(sequence, "sample_chunk", sample_chunk)
+    plan = make_prompt_plan(
+        mode=PROMPT_MODE_FIXED,
+        script="continuous shot",
+        chunks=2,
+        chunk_seconds=5.0,
+    )
+    kwargs = dict(
+        model=model,
+        clip=FakeClip(),
+        video_vae=object(),
+        audio_vae=object(),
+        sampler=object(),
+        sigmas=torch.tensor([1.0, 0.0]),
+        first_frame=None,
+        last_frame=None,
+        prompt_plan=plan,
+        width=width,
+        height=height,
+        continuity=V2_CONTINUITY_AUTO,
+        base_seed=42,
+        audio_continuity=True,
+        exact_total_duration=False,
+        diagnostics_mode=DIAGNOSTICS_BASIC,
+        reroll_from_chunk=0,
+        reroll_nonce=0,
+        strict_compatibility=True,
+        debug=False,
+        latent_only=True,
+    )
+    return kwargs
+
+
+def _enable_driving_audio(monkeypatch, kwargs):
+    source = SimpleNamespace(contract={"test": "driving-audio"})
+    kwargs["driving_audio_source"] = source
+    kwargs["driving_audio_vae"] = object()
+    monkeypatch.setattr(
+        sequence,
+        "combine_driving_audio_identity",
+        lambda identity, source: f"{identity}:driving",
+    )
+    monkeypatch.setattr(sequence, "encode_driving_audio", lambda source, vae: object())
+    monkeypatch.setattr(
+        sequence,
+        "slice_driving_audio_latent",
+        lambda *args, **kwargs: torch.zeros(1, 32, 2, 1),
+    )
+    monkeypatch.setattr(sequence, "attach_driving_audio", lambda conditioning, latent: conditioning)
+    return source
+
+
+def test_native_sequence_has_no_chunk1_prefix_uses_previous_accepted_latent_and_skips_legacy_rope_path(monkeypatch):
+    events = []
+    kwargs = _install_common_runtime(monkeypatch, events)
+    masked_calls = []
+
+    def masked(latent, *, video_context, audio_context, context_frames):
+        masked_calls.append(
+            (
+                context_frames,
+                video_context.detach().clone(),
+                audio_context.detach().clone() if audio_context is not None else None,
+            )
+        )
+        latent = dict(latent)
+        latent["noise_mask"] = "native-mask"
+        return latent
+
+    monkeypatch.setattr(sequence, "apply_native_masked_continuation", masked)
+    monkeypatch.setattr(
+        sequence,
+        "prepare_conditioning",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("native continuation must not enter legacy reference/RoPE preparation")
+        ),
+    )
+
+    with continuation_method_scope(CONTINUATION_NATIVE_MASKED):
+        entries, last_state, session, report = sequence.run_sequence(**kwargs)
+
+    assert [event[2] for event in events if event[0] == "sample"] == [False, True]
+    assert len(masked_calls) == 1
+    context_frames, video_context, audio_context = masked_calls[0]
+    assert context_frames == 39
+    assert torch.all(video_context == 1.0)
+    assert torch.all(audio_context == 10.0)
+    clone_events = [event for event in events if event[0] == "clone"]
+    assert clone_events[0][2] is None
+    assert clone_events[1][2] == 39
+    assert clone_events[1][3]["min_actual_prefix_steps"] == 2
+    assert entries[0]["plan"].get("continuation_method") is None
+    assert entries[1]["plan"]["continuation_method"] == CONTINUATION_NATIVE_MASKED
+    assert entries[1]["plan"]["trim_frames"] == 39
+    assert entries[1]["plan"]["net_frames"] == entries[1]["plan"]["total_frames"] - 39
+    assert last_state["clip_index"] == 2
+    assert session["settings"]["continuation_method"] == CONTINUATION_NATIVE_MASKED
+    assert "Continuation method: Native Masked" in report
+
+
+def test_native_three_chunk_run_uses_immediately_previous_accepted_state_without_stale_context(monkeypatch):
+    events = []
+    kwargs = _install_common_runtime(monkeypatch, events)
+    kwargs["prompt_plan"] = make_prompt_plan(
+        mode=PROMPT_MODE_FIXED,
+        script="continuous shot",
+        chunks=3,
+        chunk_seconds=5.0,
+    )
+    captured = []
+
+    def masked(latent, *, video_context, audio_context, context_frames):
+        captured.append((
+            float(video_context.mean()),
+            float(audio_context.mean()),
+            context_frames,
+        ))
+        latent = dict(latent)
+        latent["noise_mask"] = "native-mask"
+        return latent
+
+    monkeypatch.setattr(sequence, "apply_native_masked_continuation", masked)
+
+    with continuation_method_scope(CONTINUATION_NATIVE_MASKED):
+        entries, last_state, _session, _report = sequence.run_sequence(**kwargs)
+
+    assert captured == [(1.0, 10.0, 39), (2.0, 20.0, 39)]
+    assert len(entries) == 3
+    assert last_state["clip_index"] == 3
+    assert [event[2] for event in events if event[0] == "sample"] == [False, True, True]
+
+
+def test_guide_sequence_still_uses_legacy_conditioning_path_and_never_native_mask(monkeypatch):
+    events = []
+    kwargs = _install_common_runtime(monkeypatch, events)
+    guide_calls = []
+
+    def guide(conditioning, **kwargs):
+        guide_calls.append(kwargs)
+        return conditioning
+
+    monkeypatch.setattr(sequence, "prepare_conditioning", guide)
+    monkeypatch.setattr(
+        sequence,
+        "apply_native_masked_continuation",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("Guide mode must not use the native masked target path")
+        ),
+    )
+
+    with continuation_method_scope(CONTINUATION_GUIDE):
+        entries, _last_state, session, report = sequence.run_sequence(**kwargs)
+
+    assert len(guide_calls) == 1
+    assert guide_calls[0]["context_frames"] in (5, 22, 39)
+    assert [event[2] for event in events if event[0] == "sample"] == [False, False]
+    assert entries[1]["plan"].get("continuation_method") is None
+    assert session["settings"]["continuation_method"] == CONTINUATION_GUIDE
+    assert "Continuation method: Guide / Motion Context" in report
+
+
+def test_driving_audio_disables_generated_audio_continuity_for_native_mask(monkeypatch):
+    events = []
+    kwargs = _install_common_runtime(monkeypatch, events)
+    _enable_driving_audio(monkeypatch, kwargs)
+    kwargs["continuity"] = V2_CONTINUITY_OPTIONS[1]  # 22 frames is video-valid, AV-inexact.
+    masked_audio_contexts = []
+
+    def masked(latent, *, video_context, audio_context, context_frames):
+        masked_audio_contexts.append(audio_context)
+        latent = dict(latent)
+        latent["noise_mask"] = "native-mask"
+        return latent
+
+    monkeypatch.setattr(sequence, "apply_native_masked_continuation", masked)
+
+    with continuation_method_scope(CONTINUATION_NATIVE_MASKED):
+        entries, _last_state, session, report = sequence.run_sequence(**kwargs)
+
+    assert masked_audio_contexts == [None]
+    assert entries[1]["plan"]["trim_frames"] == 22
+    assert session["settings"]["driving_audio_contract"] == {"test": "driving-audio"}
+    assert "generated-audio continuation is disabled" in report
+
+
+def test_driving_audio_also_prevents_legacy_guide_from_reusing_generated_audio(monkeypatch):
+    events = []
+    kwargs = _install_common_runtime(monkeypatch, events)
+    _enable_driving_audio(monkeypatch, kwargs)
+    guide_audio_contexts = []
+
+    def guide(conditioning, **kwargs):
+        guide_audio_contexts.append(kwargs["audio_context"])
+        return conditioning
+
+    monkeypatch.setattr(sequence, "prepare_conditioning", guide)
+
+    with continuation_method_scope(CONTINUATION_GUIDE):
+        sequence.run_sequence(**kwargs)
+
+    assert guide_audio_contexts == [None]

--- a/tests/test_reference_autogrow.py
+++ b/tests/test_reference_autogrow.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from ComfyUI_H3_Continuum_Join.v3.driving_nodes import H3ContinuumSamplerV34
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_v34_sampler_declares_all_eight_reference_inputs():
+    optional = H3ContinuumSamplerV34.INPUT_TYPES()["optional"]
+    for index in range(1, 9):
+        assert optional[f"reference_image_{index}"][0] == "IMAGE"
+
+
+def test_v34_frontend_keeps_three_visible_and_grows_to_eight():
+    source = (ROOT / "web" / "v34_ui.js").read_text(encoding="utf-8")
+    assert "const BASE_REFERENCE_INPUTS = 3;" in source
+    assert "const MAX_REFERENCE_INPUTS = 8;" in source
+    assert "node.addInput?.(`reference_image_${index}`, \"IMAGE\")" in source
+    assert "node.removeInput?.(slot)" in source
+    assert "highestConnected + 1" in source

--- a/tests/test_reference_interop.py
+++ b/tests/test_reference_interop.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import torch
+
+from ComfyUI_H3_Continuum_Join.constants import (
+    CONTINUUM_INTEROP_API,
+    CONTINUUM_REFERENCE_AUDIO_ROLE_AUDIO_CONTEXT,
+    CONTINUUM_REFERENCE_METADATA_KEY,
+    CONTINUUM_REFERENCE_PRESERVE_ROPE_KEY,
+    CONTINUUM_REFERENCE_ROLE_VIDEO_CONTEXT,
+)
+from ComfyUI_H3_Continuum_Join.continuation import POLICY_REPLACE, prepare_conditioning
+
+
+def test_continuation_reference_publishes_stable_external_patch_metadata():
+    conditioning = [
+        [
+            torch.zeros((1, 4, 8)),
+            {
+                "minimax_refs": [
+                    {
+                        "kind": "image",
+                        "latent_h": 4,
+                        "latent_w": 4,
+                    }
+                ]
+            },
+        ]
+    ]
+    video_context = torch.zeros((1, 24, 2, 4, 4))
+    audio_context = torch.zeros((1, 32, 2, 8))
+
+    prepared = prepare_conditioning(
+        conditioning,
+        video_context=video_context,
+        audio_context=audio_context,
+        audio_grid_offset=0.0,
+        context_frames=5,
+        new_frame_count=121,
+        first_frame_policy=POLICY_REPLACE,
+        preserve_last_frame=False,
+    )
+
+    refs = prepared[0][1]["minimax_refs"]
+    assert len(refs) == 2
+    assert refs[0]["kind"] == "image"
+
+    continuation_ref = refs[1]
+    assert continuation_ref["kind"] == "video_audio"
+    metadata = continuation_ref[CONTINUUM_REFERENCE_METADATA_KEY]
+    assert metadata == {
+        "api": CONTINUUM_INTEROP_API,
+        "role": CONTINUUM_REFERENCE_ROLE_VIDEO_CONTEXT,
+        "audio_role": CONTINUUM_REFERENCE_AUDIO_ROLE_AUDIO_CONTEXT,
+        CONTINUUM_REFERENCE_PRESERVE_ROPE_KEY: True,
+    }
+
+
+def test_video_only_continuation_still_marks_rope_preservation():
+    prepared = prepare_conditioning(
+        [[torch.zeros((1, 2, 4)), {}]],
+        video_context=torch.zeros((1, 24, 1, 4, 4)),
+        audio_context=None,
+        audio_grid_offset=0.0,
+        context_frames=1,
+        new_frame_count=25,
+        first_frame_policy=POLICY_REPLACE,
+        preserve_last_frame=False,
+    )
+
+    ref = prepared[0][1]["minimax_refs"][0]
+    metadata = ref[CONTINUUM_REFERENCE_METADATA_KEY]
+    assert ref["kind"] == "video"
+    assert metadata["api"] == CONTINUUM_INTEROP_API
+    assert metadata["role"] == CONTINUUM_REFERENCE_ROLE_VIDEO_CONTEXT
+    assert metadata["audio_role"] is None
+    assert metadata[CONTINUUM_REFERENCE_PRESERVE_ROPE_KEY] is True
+
+
+def test_reference_kinds_remain_distinct_for_downstream_minimax_payload():
+    """Continuum must not collapse image/video/video_audio into one visual label."""
+    conditioning = [
+        [
+            torch.zeros((1, 4, 8)),
+            {
+                "minimax_refs": [
+                    {"kind": "image", "latent_h": 4, "latent_w": 4},
+                    {
+                        "kind": "video",
+                        "latent_t": 1,
+                        "latent_h": 4,
+                        "latent_w": 4,
+                        "latent": torch.zeros((1, 24, 1, 4, 4)),
+                    },
+                ]
+            },
+        ]
+    ]
+
+    prepared = prepare_conditioning(
+        conditioning,
+        video_context=torch.zeros((1, 24, 2, 4, 4)),
+        audio_context=torch.zeros((1, 32, 2, 8)),
+        audio_grid_offset=0.0,
+        context_frames=5,
+        new_frame_count=121,
+        first_frame_policy=POLICY_REPLACE,
+        preserve_last_frame=False,
+    )
+
+    refs = prepared[0][1]["minimax_refs"]
+    assert [ref["kind"] for ref in refs] == ["image", "video", "video_audio"]
+    assert refs[0] is not conditioning[0][1]["minimax_refs"][0]
+    assert refs[1] is not conditioning[0][1]["minimax_refs"][1]
+    assert refs[2][CONTINUUM_REFERENCE_METADATA_KEY][CONTINUUM_REFERENCE_PRESERVE_ROPE_KEY] is True

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2,6 +2,7 @@ import pytest
 
 from ComfyUI_H3_Continuum_Join.temporal import (
     align_frame_count_nearest,
+    align_frame_count_up,
     audio_grid_offset,
     audio_latent_t,
     context_slots,
@@ -9,6 +10,7 @@ from ComfyUI_H3_Continuum_Join.temporal import (
     largest_context_capacity,
     make_av_context_window,
     make_extension_shape,
+    make_extension_shape_at_least,
     pixel_frames_for_latent_t,
     video_latent_t,
 )
@@ -38,6 +40,40 @@ def test_balanced_five_second_extension():
 def test_nearest_grid_choice():
     assert align_frame_count_nearest(13) == 5
     assert align_frame_count_nearest(14) == 22
+
+
+def test_minimum_extension_rounds_up_instead_of_undershooting():
+    shape = make_extension_shape_at_least(22, 161)
+    assert shape.total_frames == 192
+    assert shape.net_new_frames == 170
+    assert shape.net_new_frames >= shape.requested_new_frames
+    assert shape.net_new_frames - shape.requested_new_frames < 17
+
+
+def test_minimum_extension_never_undershoots_across_ui_range():
+    for context in (5, 22, 39):
+        for requested_new_frames in range(1, 15 * 24 + 1):
+            shape = make_extension_shape_at_least(context, requested_new_frames)
+            assert shape.total_frames % 17 == 5
+            assert shape.net_new_frames >= requested_new_frames
+            assert shape.net_new_frames - requested_new_frames < 17
+            assert pixel_frames_for_latent_t(shape.video_latent_t) == shape.total_frames
+
+
+def test_two_seven_second_chunks_generate_surplus_instead_of_frozen_tail_padding():
+    target_per_chunk = round(7.0 * 24)
+    target_total = 2 * target_per_chunk
+    first_frames = align_frame_count_up(target_per_chunk)
+    requested_second = target_total - first_frames
+    second = make_extension_shape_at_least(22, requested_second)
+    natural_frames = first_frames + second.net_new_frames
+
+    assert first_frames == 175
+    assert requested_second == 161
+    assert second.total_frames == 192
+    assert second.net_new_frames == 170
+    assert natural_frames == 345
+    assert natural_frames >= target_total
 
 
 def test_audio_grid_offset_is_signed_and_bounded_on_valid_h3_lengths():

--- a/tests/test_v34_facade.py
+++ b/tests/test_v34_facade.py
@@ -3,6 +3,7 @@ import torch
 
 from ComfyUI_H3_Continuum_Join.constants import V2_CONTINUITY_OPTIONS
 from ComfyUI_H3_Continuum_Join.masked_continuation import (
+    CONTINUATION_GUIDE,
     CONTINUATION_METHODS,
     CONTINUATION_NATIVE_MASKED,
     NativeMaskedContinuationError,
@@ -112,7 +113,43 @@ def test_v34_invalid_native_generated_audio_profile_fails_before_parent_sampling
     assert parent_called is False
 
 
-def test_v34_reference_mode_precedence_and_extra_reference_bundle(monkeypatch):
+@pytest.mark.parametrize("continuation_method", [CONTINUATION_NATIVE_MASKED, CONTINUATION_GUIDE])
+@pytest.mark.parametrize(
+    ("first_frame", "last_frame"),
+    [
+        ("first", None),
+        (None, "last"),
+        ("first", "last"),
+    ],
+)
+def test_v34_preserves_hybrid_keyframes_with_reference_for_both_continuation_methods(
+    monkeypatch, continuation_method, first_frame, last_frame
+):
+    captured = {}
+    ref = torch.zeros((1, 8, 8, 3))
+
+    def fake_run(self, **kwargs):
+        captured.update(kwargs)
+        return ["v"], ["a"], {"target_frames": 120}, "status"
+
+    monkeypatch.setattr(H3ContinuumSamplerProduction, "run", fake_run)
+    H3ContinuumSamplerV34().run(
+        chunks=1,
+        chunk_seconds=5.0,
+        width=64,
+        height=64,
+        first_frame=first_frame,
+        last_frame=last_frame,
+        reference_image_1=ref,
+        continuation_method=continuation_method,
+    )
+
+    assert captured["first_frame"] == first_frame
+    assert captured["last_frame"] == last_frame
+    assert captured["reference_image_1"] is ref
+
+
+def test_v34_preserves_hybrid_keyframes_and_bundles_extra_references(monkeypatch):
     captured = {}
     ref3 = torch.zeros((1, 8, 8, 3))
     ref4 = torch.ones((1, 10, 6, 3))
@@ -135,8 +172,8 @@ def test_v34_reference_mode_precedence_and_extra_reference_bundle(monkeypatch):
         reference_image_8=ref8,
     )
 
-    assert captured["first_frame"] is None
-    assert captured["last_frame"] is None
+    assert captured["first_frame"] == "first"
+    assert captured["last_frame"] == "last"
     bundle = captured["reference_image_3"]
     assert isinstance(bundle, ReferenceImageBundle)
     assert bundle.images == (ref3, ref4, ref8)

--- a/tests/test_v34_facade.py
+++ b/tests/test_v34_facade.py
@@ -1,0 +1,75 @@
+import torch
+
+from ComfyUI_H3_Continuum_Join.nodes import NODE_CLASS_MAPPINGS
+from ComfyUI_H3_Continuum_Join.reference import ReferenceImageBundle
+from ComfyUI_H3_Continuum_Join.v3.driving_nodes import (
+    H3ContinuumAssembleSeamV34,
+    H3ContinuumSamplerV34,
+)
+from ComfyUI_H3_Continuum_Join.v3.nodes import H3ContinuumSamplerProduction
+
+
+def test_v34_public_nodes_are_registered():
+    assert NODE_CLASS_MAPPINGS["H3ContinuumSamplerV34"] is H3ContinuumSamplerV34
+    assert NODE_CLASS_MAPPINGS["H3ContinuumAssembleSeamV34"] is H3ContinuumAssembleSeamV34
+
+
+def test_v34_sampler_extends_official_contract_to_eight_references_only():
+    v34_optional = H3ContinuumSamplerV34.INPUT_TYPES()["optional"]
+    legacy_optional = H3ContinuumSamplerProduction.INPUT_TYPES()["optional"]
+
+    for index in range(1, 9):
+        assert v34_optional[f"reference_image_{index}"][0] == "IMAGE"
+    for index in range(1, 4):
+        assert legacy_optional[f"reference_image_{index}"][0] == "IMAGE"
+    for index in range(4, 9):
+        assert f"reference_image_{index}" not in legacy_optional
+
+    assert v34_optional["reference_video_1"][0] == "IMAGE"
+    assert v34_optional["driving_audio"][0] == "AUDIO"
+    assert v34_optional["audio_vae"][0] == "VAE"
+    assert "reference_audio_1" not in v34_optional
+    assert "reference_audio_vae" not in v34_optional
+    assert H3ContinuumSamplerV34.RETURN_NAMES == (
+        "video_latents",
+        "audio_latents",
+        "assembly_plan",
+        "status",
+        "driving_audio",
+    )
+    assert H3ContinuumSamplerV34.OUTPUT_IS_LIST == (True, True, False, False, False)
+
+
+def test_v34_reference_mode_precedence_and_extra_reference_bundle(monkeypatch):
+    captured = {}
+    ref3 = torch.zeros((1, 8, 8, 3))
+    ref4 = torch.ones((1, 10, 6, 3))
+    ref8 = torch.full((1, 4, 12, 3), 8.0)
+
+    def fake_run(self, **kwargs):
+        captured.update(kwargs)
+        return ["v"], ["a"], {"target_frames": 120}, "status"
+
+    monkeypatch.setattr(H3ContinuumSamplerProduction, "run", fake_run)
+    outputs = H3ContinuumSamplerV34().run(
+        chunks=1,
+        chunk_seconds=5.0,
+        width=64,
+        height=64,
+        first_frame="first",
+        last_frame="last",
+        reference_image_3=ref3,
+        reference_image_4=ref4,
+        reference_image_8=ref8,
+    )
+
+    assert captured["first_frame"] is None
+    assert captured["last_frame"] is None
+    bundle = captured["reference_image_3"]
+    assert isinstance(bundle, ReferenceImageBundle)
+    assert bundle.images == (ref3, ref4, ref8)
+    assert "reference_image_4" not in captured
+    assert "reference_image_8" not in captured
+    assert captured["driving_audio_source"] is None
+    assert captured["reference_video_source"] is None
+    assert outputs == (["v"], ["a"], {"target_frames": 120}, "status", None)

--- a/tests/test_v34_facade.py
+++ b/tests/test_v34_facade.py
@@ -1,8 +1,17 @@
+import pytest
 import torch
 
+from ComfyUI_H3_Continuum_Join.constants import V2_CONTINUITY_OPTIONS
+from ComfyUI_H3_Continuum_Join.masked_continuation import (
+    CONTINUATION_METHODS,
+    CONTINUATION_NATIVE_MASKED,
+    NativeMaskedContinuationError,
+)
 from ComfyUI_H3_Continuum_Join.nodes import NODE_CLASS_MAPPINGS
 from ComfyUI_H3_Continuum_Join.reference import ReferenceImageBundle
 from ComfyUI_H3_Continuum_Join.v3.driving_nodes import (
+    V34_CONTINUITY_OPTIONS,
+    V34_CONTINUITY_STRONG,
     H3ContinuumAssembleSeamV34,
     H3ContinuumSamplerV34,
 )
@@ -12,6 +21,47 @@ from ComfyUI_H3_Continuum_Join.v3.nodes import H3ContinuumSamplerProduction
 def test_v34_public_nodes_are_registered():
     assert NODE_CLASS_MAPPINGS["H3ContinuumSamplerV34"] is H3ContinuumSamplerV34
     assert NODE_CLASS_MAPPINGS["H3ContinuumAssembleSeamV34"] is H3ContinuumAssembleSeamV34
+
+
+def test_v34_native_masked_is_default_without_changing_v33_contract():
+    v34_required = H3ContinuumSamplerV34.INPUT_TYPES()["required"]
+    legacy_required = H3ContinuumSamplerProduction.INPUT_TYPES()["required"]
+
+    method = v34_required["continuation_method"]
+    assert method[0] == CONTINUATION_METHODS
+    assert method[1]["default"] == CONTINUATION_NATIVE_MASKED
+    assert v34_required["continuity"][0] == V34_CONTINUITY_OPTIONS
+    assert v34_required["continuity"][1]["default"] == V34_CONTINUITY_STRONG
+    assert V34_CONTINUITY_STRONG == "Strong — 39 frames"
+    assert V2_CONTINUITY_OPTIONS[3] in V34_CONTINUITY_OPTIONS
+    assert "continuation_method" not in legacy_required
+    assert legacy_required["continuity"][1]["default"] != V2_CONTINUITY_OPTIONS[3]
+
+
+@pytest.mark.parametrize(
+    "continuity",
+    [V34_CONTINUITY_STRONG, V2_CONTINUITY_OPTIONS[3]],
+)
+def test_v34_strong_values_normalize_before_legacy_sequence_engine(monkeypatch, continuity):
+    captured = {}
+
+    def fake_run(self, **kwargs):
+        captured.update(kwargs)
+        return ["v"], ["a"], {"target_frames": 120}, "status"
+
+    monkeypatch.setattr(H3ContinuumSamplerProduction, "run", fake_run)
+    outputs = H3ContinuumSamplerV34().run(
+        chunks=1,
+        chunk_seconds=5.0,
+        width=64,
+        height=64,
+        continuity=continuity,
+        audio_continuity=True,
+        continuation_method=CONTINUATION_NATIVE_MASKED,
+    )
+
+    assert captured["continuity"] == V2_CONTINUITY_OPTIONS[3]
+    assert outputs == (["v"], ["a"], {"target_frames": 120}, "status", None)
 
 
 def test_v34_sampler_extends_official_contract_to_eight_references_only():
@@ -38,6 +88,28 @@ def test_v34_sampler_extends_official_contract_to_eight_references_only():
         "driving_audio",
     )
     assert H3ContinuumSamplerV34.OUTPUT_IS_LIST == (True, True, False, False, False)
+
+
+def test_v34_invalid_native_generated_audio_profile_fails_before_parent_sampling(monkeypatch):
+    parent_called = False
+
+    def fake_run(self, **kwargs):
+        nonlocal parent_called
+        parent_called = True
+        raise AssertionError("invalid native AV settings must fail before parent sampling")
+
+    monkeypatch.setattr(H3ContinuumSamplerProduction, "run", fake_run)
+    with pytest.raises(NativeMaskedContinuationError, match="22 video frames"):
+        H3ContinuumSamplerV34().run(
+            chunks=2,
+            chunk_seconds=5.0,
+            width=64,
+            height=64,
+            continuity=V2_CONTINUITY_OPTIONS[1],
+            audio_continuity=True,
+            continuation_method=CONTINUATION_NATIVE_MASKED,
+        )
+    assert parent_called is False
 
 
 def test_v34_reference_mode_precedence_and_extra_reference_bundle(monkeypatch):
@@ -72,4 +144,5 @@ def test_v34_reference_mode_precedence_and_extra_reference_bundle(monkeypatch):
     assert "reference_image_8" not in captured
     assert captured["driving_audio_source"] is None
     assert captured["reference_video_source"] is None
+    assert captured["continuity"] == V2_CONTINUITY_OPTIONS[3]
     assert outputs == (["v"], ["a"], {"target_frames": 120}, "status", None)

--- a/tests/test_v34_hybrid_conditioning.py
+++ b/tests/test_v34_hybrid_conditioning.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import torch
+
+from ComfyUI_H3_Continuum_Join.conditioning import conditioning_mode_from_presence
+from ComfyUI_H3_Continuum_Join.constants import MARK_VIDEO_CONTEXT
+from ComfyUI_H3_Continuum_Join.continuation import POLICY_REPLACE, prepare_conditioning
+from ComfyUI_H3_Continuum_Join.masked_continuation import prepare_masked_conditioning
+from ComfyUI_H3_Continuum_Join.reference import (
+    REFERENCE_SIZE_MATCH_OUTPUT,
+    ReferenceAssets,
+    encode_reference_prompt,
+)
+from ComfyUI_H3_Continuum_Join.v2.h3_builder import attach_keyframes
+
+
+class _Clip:
+    def __init__(self):
+        self.items = None
+
+    def tokenize(self, prompt, *, minimax_ref_items):
+        self.items = list(minimax_ref_items)
+        return prompt
+
+    def encode_from_tokens_scheduled(self, tokens):
+        return [[torch.zeros(1, 1, 2), {}]]
+
+
+def _reference_assets() -> ReferenceAssets:
+    image = torch.zeros((1, 32, 32, 3))
+    latent = torch.zeros((1, 24, 1, 2, 2))
+    return ReferenceAssets(
+        images=(image,),
+        latents=(latent,),
+        image_hashes=("1" * 64,),
+        combined_hash="2" * 64,
+        size_mode=REFERENCE_SIZE_MATCH_OUTPUT,
+    )
+
+
+def _hybrid_conditioning(*, frame_count: int = 141):
+    clip = _Clip()
+    conditioning = encode_reference_prompt(
+        clip,
+        "<Picture 1> remains the same person",
+        _reference_assets(),
+    )
+    first_latent = torch.ones((1, 24, 1, 2, 2))
+    last_latent = torch.full((1, 24, 1, 2, 2), 2.0)
+    conditioning = attach_keyframes(
+        conditioning,
+        frame_count=frame_count,
+        first_latent=first_latent,
+        last_latent=last_latent,
+    )
+    return clip, conditioning, first_latent, last_latent
+
+
+def test_core_shaped_reference_presentation_and_keyframes_coexist():
+    clip, conditioning, first_latent, last_latent = _hybrid_conditioning()
+
+    assert len(clip.items) == 1
+    assert clip.items[0]["type"] == "image"
+    metadata = conditioning[0][1]
+    assert [ref["kind"] for ref in metadata["minimax_refs"]] == ["image"]
+    assert metadata["minimax_keyframes"] == [
+        {"resolved_frame_index": 0, "latent": first_latent},
+        {"resolved_frame_index": 140, "latent": last_latent},
+    ]
+    assert metadata["minimax_frame_count"] == 141
+
+
+def test_native_masked_hybrid_drops_only_prefix_keyframe_and_keeps_reference_and_last():
+    _clip, conditioning, _first_latent, last_latent = _hybrid_conditioning()
+
+    output = prepare_masked_conditioning(
+        conditioning,
+        context_frames=39,
+        new_frame_count=141,
+    )
+    metadata = output[0][1]
+
+    assert [ref["kind"] for ref in metadata["minimax_refs"]] == ["image"]
+    assert metadata["minimax_keyframes"] == [
+        {"resolved_frame_index": 140, "latent": last_latent}
+    ]
+    assert metadata["minimax_frame_count"] == 141
+
+
+def test_guide_hybrid_replaces_first_with_context_and_keeps_reference_and_last():
+    _clip, conditioning, _first_latent, last_latent = _hybrid_conditioning(
+        frame_count=124
+    )
+
+    output = prepare_conditioning(
+        conditioning,
+        video_context=torch.zeros((1, 24, 7, 2, 2)),
+        audio_context=None,
+        audio_grid_offset=0.0,
+        context_frames=22,
+        new_frame_count=141,
+        first_frame_policy=POLICY_REPLACE,
+        preserve_last_frame=True,
+    )
+    metadata = output[0][1]
+
+    assert metadata["minimax_keyframes"] == [
+        {"resolved_frame_index": 140, "latent": last_latent}
+    ]
+    refs = metadata["minimax_refs"]
+    assert [ref["kind"] for ref in refs] == ["image", "video"]
+    assert refs[1][MARK_VIDEO_CONTEXT] is True
+    assert metadata["minimax_frame_count"] == 141
+
+
+def _patch_sampling_observation(monkeypatch):
+    import ComfyUI_H3_Continuum_Join.run_storage as storage
+
+    monkeypatch.setattr(storage, "_model_signature", lambda *a, **k: ({"model": 1}, True))
+    monkeypatch.setattr(storage, "_clip_signature", lambda *a, **k: ({"clip": 1}, True))
+    monkeypatch.setattr(
+        storage,
+        "_video_vae_signature",
+        lambda *a, **k: ({"video_vae": 1}, True),
+    )
+    monkeypatch.setattr(storage, "_sampler_signature", lambda *a, **k: ({"sampler": 1}, True))
+    return storage
+
+
+def _sampling_contract(
+    monkeypatch,
+    *,
+    has_first: bool,
+    has_last: bool,
+    first_hash: str = "a" * 64,
+    last_hash: str = "b" * 64,
+):
+    storage = _patch_sampling_observation(monkeypatch)
+    reference_contract = _reference_assets().contract
+    mode = conditioning_mode_from_presence(
+        has_first=has_first,
+        has_last=has_last,
+        has_reference=True,
+    )
+    contract, safe, reasons = storage.build_sampling_contract(
+        model=object(),
+        model_fingerprint_value="model",
+        clip=object(),
+        video_vae=object(),
+        sampler=object(),
+        sigmas=torch.tensor([1.0, 0.0]),
+        prompt_plan={
+            "chunks": 3,
+            "hashes": ["3" * 64, "4" * 64, "5" * 64],
+            "mode": "fixed",
+        },
+        width=96,
+        height=64,
+        chunk_seconds=5.0,
+        continuity="Strong — 39 frames (Experimental)",
+        audio_continuity=True,
+        base_seed=1,
+        reroll_from_chunk=0,
+        reroll_nonce=0,
+        first_frame_hash=first_hash if has_first else "none",
+        last_frame_hash=last_hash if has_last else "none",
+        strict_compatibility=False,
+        reference_contract=reference_contract,
+        conditioning_mode=mode,
+    )
+    assert safe, reasons
+    return contract
+
+
+def test_run_storage_hybrid_first_and_reference_fingerprint_both_inputs(monkeypatch):
+    first = _sampling_contract(
+        monkeypatch,
+        has_first=True,
+        has_last=False,
+        first_hash="a" * 64,
+    )
+    changed = _sampling_contract(
+        monkeypatch,
+        has_first=True,
+        has_last=False,
+        first_hash="c" * 64,
+    )
+
+    assert first["global"]["conditioning_mode"] == "i2va"
+    assert first["global"]["first_frame_hash"] == "a" * 64
+    assert first["global"]["reference"] == _reference_assets().contract
+    assert first["chunk_contract_hashes"] != changed["chunk_contract_hashes"]
+
+
+def test_run_storage_hybrid_last_and_reference_invalidates_only_final_chunk(monkeypatch):
+    first = _sampling_contract(
+        monkeypatch,
+        has_first=False,
+        has_last=True,
+        last_hash="b" * 64,
+    )
+    changed = _sampling_contract(
+        monkeypatch,
+        has_first=False,
+        has_last=True,
+        last_hash="d" * 64,
+    )
+
+    assert first["global"]["conditioning_mode"] == "last_only"
+    assert first["global"]["reference"] == _reference_assets().contract
+    assert first["chunk_contract_hashes"][:2] == changed["chunk_contract_hashes"][:2]
+    assert first["chunk_contract_hashes"][2] != changed["chunk_contract_hashes"][2]
+
+
+def test_run_storage_first_last_reference_tracks_first_globally_and_last_at_tail(monkeypatch):
+    baseline = _sampling_contract(
+        monkeypatch,
+        has_first=True,
+        has_last=True,
+        first_hash="a" * 64,
+        last_hash="b" * 64,
+    )
+    changed_first = _sampling_contract(
+        monkeypatch,
+        has_first=True,
+        has_last=True,
+        first_hash="c" * 64,
+        last_hash="b" * 64,
+    )
+    changed_last = _sampling_contract(
+        monkeypatch,
+        has_first=True,
+        has_last=True,
+        first_hash="a" * 64,
+        last_hash="d" * 64,
+    )
+
+    assert baseline["global"]["conditioning_mode"] == "fl2va"
+    assert baseline["global"]["first_frame_hash"] == "a" * 64
+    assert baseline["global"]["reference"] == _reference_assets().contract
+    assert baseline["chunk_contract_hashes"] != changed_first["chunk_contract_hashes"]
+    assert baseline["chunk_contract_hashes"][:2] == changed_last["chunk_contract_hashes"][:2]
+    assert baseline["chunk_contract_hashes"][2] != changed_last["chunk_contract_hashes"][2]

--- a/tests/test_v3_memory_pressure.py
+++ b/tests/test_v3_memory_pressure.py
@@ -1,0 +1,158 @@
+import torch
+
+from ComfyUI_H3_Continuum_Join.constants import DIAGNOSTICS_FULL
+from ComfyUI_H3_Continuum_Join.hardening import enrich_assembly_plan
+from ComfyUI_H3_Continuum_Join.v3.assembly import (
+    AUDIO_SEAM_OFF,
+    H3ContinuumAssembleSeamExperimental,
+    H3ContinuumAssembleV3,
+    IMAGE_OUTPUT_CPU,
+    _enforce_image_duration_in_place,
+    assemble_decoded_chunks,
+)
+from ComfyUI_H3_Continuum_Join.v3.plan import ASSEMBLY_PLAN_MAGIC
+from ComfyUI_H3_Continuum_Join.v3.video_seam import (
+    analyze_decoded_boundaries,
+    build_decoded_boundary_patches,
+)
+
+
+def _plan(*, width=8, height=8):
+    return enrich_assembly_plan(
+        {
+            "magic": ASSEMBLY_PLAN_MAGIC,
+            "schema_version": 1,
+            "fps": 24,
+            "width": width,
+            "height": height,
+            "chunk_seconds": 5.0,
+            "target_frames": 240,
+            "preserve_final_frame": True,
+            "chunks": [
+                {
+                    "sequence_index": 1,
+                    "chunk_index": 1,
+                    "total_frames": 124,
+                    "trim_frames": 0,
+                    "net_frames": 124,
+                    "context_frames": 0,
+                    "expected_video_latent_t": 32,
+                    "expected_audio_latent_t": 207,
+                },
+                {
+                    "sequence_index": 2,
+                    "chunk_index": 2,
+                    "total_frames": 141,
+                    "trim_frames": 22,
+                    "net_frames": 119,
+                    "context_frames": 22,
+                    "expected_video_latent_t": 36,
+                    "expected_audio_latent_t": 235,
+                },
+            ],
+        }
+    )
+
+
+def _decoded(*, height=8, width=8):
+    images = [
+        torch.full((124, height, width, 3), 0.25, dtype=torch.float32),
+        torch.full((141, height, width, 3), 0.25, dtype=torch.float32),
+    ]
+    audio = [
+        {"waveform": torch.zeros((1, 2, 190000)), "sample_rate": 32000},
+        {"waveform": torch.zeros((1, 2, 190000)), "sample_rate": 32000},
+    ]
+    return images, audio
+
+
+def _storage_ptr(tensor):
+    return tensor.untyped_storage().data_ptr()
+
+
+def test_boundary_builder_owns_only_qualified_boundary_frames():
+    images, _audio = _decoded(height=16, width=16)
+    images[1][22] = 1.0
+    current_before = images[1].clone()
+
+    analyses = analyze_decoded_boundaries(images=images, assembly_plan=_plan())
+    patches, actions = build_decoded_boundary_patches(
+        images=images,
+        assembly_plan=_plan(),
+        analyses=analyses,
+    )
+
+    assert set(patches) == {1}
+    patch = patches[1]
+    assert patch.shape == (1, 16, 16, 3)
+    assert patch.numel() * patch.element_size() < images[1].numel() * images[1].element_size()
+    assert torch.equal(images[1], current_before)
+    assert torch.allclose(patch[0], torch.full_like(patch[0], 0.25), atol=1.0e-6)
+    assert "normalized exposure/color on 1 transient flash" in actions[1]
+
+
+def test_exact_duration_trim_reuses_owned_image_storage_and_preserves_tail():
+    buffer = torch.arange(6 * 2 * 2 * 3, dtype=torch.float32).reshape(6, 2, 2, 3)
+    original_tail = buffer[-1].clone()
+    storage_ptr = _storage_ptr(buffer)
+
+    result = _enforce_image_duration_in_place(
+        buffer,
+        current_frames=6,
+        target_frames=4,
+        preserve_final_frame=True,
+    )
+
+    assert result.shape[0] == 4
+    assert _storage_ptr(result) == storage_ptr
+    assert torch.equal(result[-1], original_tail)
+
+
+def test_exact_duration_padding_reuses_preallocated_capacity():
+    buffer = torch.empty((6, 2, 2, 3), dtype=torch.float32)
+    buffer[:4].copy_(torch.arange(4 * 2 * 2 * 3).reshape(4, 2, 2, 3))
+    last = buffer[3].clone()
+    storage_ptr = _storage_ptr(buffer)
+
+    result = _enforce_image_duration_in_place(
+        buffer,
+        current_frames=4,
+        target_frames=6,
+        preserve_final_frame=False,
+    )
+
+    assert _storage_ptr(result) == storage_ptr
+    assert torch.equal(result[4], last)
+    assert torch.equal(result[5], last)
+
+
+def test_assembler_accepts_external_2x_decoded_geometry_and_reports_it():
+    images, audio = _decoded(height=16, width=16)
+    output_images, output_audio, report = assemble_decoded_chunks(
+        images=images,
+        audio=audio,
+        assembly_plan=_plan(width=8, height=8),
+        exact_total_duration=False,
+        audio_seam=AUDIO_SEAM_OFF,
+        diagnostics=DIAGNOSTICS_FULL,
+        image_output_device=IMAGE_OUTPUT_CPU,
+    )
+
+    assert output_images.shape == (243, 16, 16, 3)
+    assert output_images.device.type == "cpu"
+    assert output_audio["sample_rate"] == 32000
+    assert "Decoded geometry: 16x16 vs plan 8x8 (2.000x/2.000x)" in report
+
+
+def test_new_output_device_widget_is_appended_after_existing_serialized_widgets():
+    base_required = list(H3ContinuumAssembleV3.INPUT_TYPES()["required"])
+    experimental_required = list(
+        H3ContinuumAssembleSeamExperimental.INPUT_TYPES()["required"]
+    )
+
+    assert base_required[-2:] == ["diagnostics", "image_output_device"]
+    assert experimental_required[-3:] == [
+        "video_seam",
+        "diagnostics",
+        "image_output_device",
+    ]

--- a/v2/sequence.py
+++ b/v2/sequence.py
@@ -13,7 +13,7 @@ from ..compatibility import accelerator_summary, check_comfy_h3_runtime
 from ..constants import (
     DIAGNOSTICS_FULL, DIAGNOSTICS_OFF, DIAGNOSTICS_OPTIONS, FPS,
     CONTINUUM_ACTUAL_PREFIX_STEPS, SEAM_CORRECTION_AUTO, SEAM_CORRECTION_OFF,
-    SEAM_CORRECTION_OPTIONS, V2_CONTINUITY_AUTO, normalize_diagnostics_mode,
+    SEAM_CORRECTION_OPTIONS, normalize_diagnostics_mode,
 )
 from ..continuation import POLICY_REPLACE, prepare_conditioning
 from ..driving_audio import (
@@ -22,6 +22,19 @@ from ..driving_audio import (
     encode_driving_audio,
     slice_driving_audio_latent,
 )
+from ..masked_continuation import (
+    CONTINUATION_GUIDE,
+    CONTINUATION_NATIVE_MASKED,
+    NATIVE_MASK_CONTRACT_VERSION,
+    apply_native_masked_continuation,
+    choose_continuation_context_frames,
+    continuation_storage_plan,
+    current_continuation_method,
+    plan_continuation_contract,
+    prepare_masked_conditioning,
+    require_native_mask_support,
+    stored_plan_matches_method,
+)
 from ..model_patch import clone_model_for_chunk
 from ..state import assert_context_unchanged, context_fingerprint, make_plan, select_context, validate_state
 from ..temporal import align_frame_count_up, largest_context_capacity, make_extension_shape, make_extension_shape_at_least
@@ -29,7 +42,6 @@ from ..version import PACKAGE_VERSION
 from .decoder import decode_sequence, decode_sequence_with_seam, enforce_total_frames
 from .context_diagnostics import ContextDiagnosticsTracker
 from .h3_builder import attach_keyframes, empty_h3_latent, encode_identity_latents, encode_prompt_conditioning, prepare_identity_assets
-from .motion import choose_context_frames
 from .prompts import prompt_plan_report, validate_prompt_plan
 from .sampling import sample_chunk
 from .seeds import derive_chunk_seed
@@ -40,10 +52,10 @@ from .session import (
 LOG=logging.getLogger("h3_continuum_join")
 class SequenceRuntimeError(RuntimeError): pass
 
-def _record_context_diagnostics(*,tracker,reports,state,continuity,reused):
+def _record_context_diagnostics(*,tracker,reports,state,continuity,reused,continuation_method=CONTINUATION_GUIDE,audio_continuity=True,driving_audio_active=False):
     if tracker is None: return
     try:
-        context_frames,_,_=choose_context_frames(continuity,state)
+        context_frames,_,_=choose_continuation_context_frames(method=continuation_method,continuity=continuity,state=state,audio_continuity=bool(audio_continuity),driving_audio_active=bool(driving_audio_active))
         video_context,_,_=select_context(state,context_frames,include_audio=False)
         reports.append(tracker.observe(video_context,source_chunk=int(state["clip_index"]),context_frames=context_frames,reused=bool(reused)))
     except Exception as exc:
@@ -62,7 +74,7 @@ def _check_decode_memory_budget(*,width,height,chunks,chunk_seconds):
 def _clone_entry_for_reuse(entry):
     entry=validate_chunk_entry(entry); result=dict(entry); result["plan"]=copy.deepcopy(entry["plan"]); result["reused"]=True; return result
 
-def _preserved_prefix(*,session,prompt_hashes,chunks,reroll_from_chunk,width,height,chunk_seconds,identity_hash):
+def _preserved_prefix(*,session,prompt_hashes,chunks,reroll_from_chunk,width,height,chunk_seconds,identity_hash,continuation_method=CONTINUATION_GUIDE):
     if session is None: return [],[]
     notes=[]
     try: session=validate_session(session)
@@ -78,6 +90,9 @@ def _preserved_prefix(*,session,prompt_hashes,chunks,reroll_from_chunk,width,hei
         try: entry=validate_chunk_entry(session["chunks"][index])
         except SessionValidationError as exc:
             notes.append(f"session reuse stopped before chunk {index+1}: stored chunk was rejected ({exc})")
+            break
+        if not stored_plan_matches_method(entry["plan"],continuation_method,chunk_number=index+1):
+            notes.append(f"session reuse stopped before chunk {index+1}: continuation method or mask contract changed")
             break
         if entry["prompt_hash"]!=prompt_hashes[index]: notes.append(f"session reuse stopped before chunk {index+1}: prompt changed"); break
         candidate_retained=retained_frames+int(entry["plan"]["net_frames"])
@@ -108,7 +123,9 @@ def run_sequence(*,model:Any,clip:Any,video_vae:Any,audio_vae:Any,sampler:Any,si
     from ..conditioning import detect_conditioning_mode, conditioning_mode_label
     from ..run_storage import get_active_run_storage
     storage_controller=get_active_run_storage()
+    continuation_method=current_continuation_method()
     diagnostics_mode=normalize_diagnostics_mode(diagnostics_mode); plan=validate_prompt_plan(prompt_plan); chunks=int(plan["chunks"]); chunk_seconds=float(plan["chunk_seconds"]); prompts=list(plan["prompts"]); prompt_hashes=list(plan["hashes"]); width,height=int(width),int(height)
+    if continuation_method==CONTINUATION_NATIVE_MASKED: require_native_mask_support()
     # Legacy workflow input only. Runtime compatibility is advisory in V3.4.
     strict_compatibility=False
     if width<=0 or height<=0 or width%32 or height%32: raise SequenceRuntimeError("width and height must be positive multiples of 32")
@@ -151,13 +168,15 @@ def run_sequence(*,model:Any,clip:Any,video_vae:Any,audio_vae:Any,sampler:Any,si
     sequence_identity_hash=combine_timeline_video_identity(sequence_identity_hash,timeline_video_source)
     current_model_fingerprint=model_fingerprint(model,extra_wrapper_keys=("h3_continuum_join.apply_model.v1",))
     if storage_controller is not None:
-        stored_session=storage_controller.prepare(model=model,model_fingerprint_value=current_model_fingerprint,clip=clip,video_vae=video_vae,sampler=sampler,sigmas=sigmas,prompt_plan=plan,width=width,height=height,chunk_seconds=chunk_seconds,continuity=continuity,audio_continuity=audio_continuity,base_seed=base_seed,reroll_from_chunk=reroll_from_chunk,reroll_nonce=reroll_nonce,first_frame_hash=assets.first_frame_hash,last_frame_hash=assets.last_frame_hash,identity_hash=sequence_identity_hash,strict_compatibility=strict_compatibility,existing_session=session,reference_contract=reference_assets.contract if reference_assets is not None else None,conditioning_mode=conditioning_mode,reference_audio_contract=reference_audio_source.contract if reference_audio_source is not None else None,reference_audio_vae=reference_audio_vae,driving_audio_contract=driving_audio_source.contract if driving_audio_source is not None else None,driving_audio_vae=driving_audio_vae,reference_video_contract=reference_video_source.contract if reference_video_source is not None else None,timeline_video_contract=timeline_video_source.contract if timeline_video_source is not None else None)
+        storage_plan=continuation_storage_plan(plan,continuation_method)
+        stored_session=storage_controller.prepare(model=model,model_fingerprint_value=current_model_fingerprint,clip=clip,video_vae=video_vae,sampler=sampler,sigmas=sigmas,prompt_plan=storage_plan,width=width,height=height,chunk_seconds=chunk_seconds,continuity=continuity,audio_continuity=audio_continuity,base_seed=base_seed,reroll_from_chunk=reroll_from_chunk,reroll_nonce=reroll_nonce,first_frame_hash=assets.first_frame_hash,last_frame_hash=assets.last_frame_hash,identity_hash=sequence_identity_hash,strict_compatibility=strict_compatibility,existing_session=session,reference_contract=reference_assets.contract if reference_assets is not None else None,conditioning_mode=conditioning_mode,reference_audio_contract=reference_audio_source.contract if reference_audio_source is not None else None,reference_audio_vae=reference_audio_vae,driving_audio_contract=driving_audio_source.contract if driving_audio_source is not None else None,driving_audio_vae=driving_audio_vae,reference_video_contract=reference_video_source.contract if reference_video_source is not None else None,timeline_video_contract=timeline_video_source.contract if timeline_video_source is not None else None)
         reroll_nonce=storage_controller.effective_reroll_nonce
         if stored_session is not None: session=stored_session
     accelerators=accelerator_summary(model)
     if "Continuum APPLY_MODEL wrapper installed" not in accelerators: accelerators+="; Continuum APPLY_MODEL wrapper installed"
     effective_reroll_from_chunk=0 if storage_controller is not None and session is not None and bool((session.get("settings") or {}).get("run_storage_validated_prefix")) else int(reroll_from_chunk)
-    preserved,reuse_notes=_preserved_prefix(session=session,prompt_hashes=prompt_hashes,chunks=chunks,reroll_from_chunk=effective_reroll_from_chunk,width=width,height=height,chunk_seconds=chunk_seconds,identity_hash=sequence_identity_hash)
+    preserved,reuse_notes=_preserved_prefix(session=session,prompt_hashes=prompt_hashes,chunks=chunks,reroll_from_chunk=effective_reroll_from_chunk,width=width,height=height,chunk_seconds=chunk_seconds,identity_hash=sequence_identity_hash,continuation_method=continuation_method)
+    reuse_notes.insert(0,f"Continuation method: {continuation_method}."+(f" Native mask contract v{NATIVE_MASK_CONTRACT_VERSION}." if continuation_method==CONTINUATION_NATIVE_MASKED else ""))
     if reference_assets is not None:
         reuse_notes.insert(0,f"Reference conditioning: {reference_assets.count} image(s), size={reference_assets.size_mode}; persistent across all chunks.")
         if reference_warning: reuse_notes.append(reference_warning)
@@ -165,7 +184,7 @@ def run_sequence(*,model:Any,clip:Any,video_vae:Any,audio_vae:Any,sampler:Any,si
         reuse_notes.insert(0,"Reference Audio 1 conditioning: persistent across all chunks.")
         if reference_audio_warning: reuse_notes.append(reference_audio_warning)
     if driving_audio_source is not None:
-        reuse_notes.insert(0,"Driving Audio: absolute-time guide slices enabled; original audio is preserved for final output.")
+        reuse_notes.insert(0,"Driving Audio: absolute-time guide slices enabled; original audio is preserved for final output; generated-audio continuation is disabled while Driving Audio is authoritative.")
     if reference_video_source is not None:
         reuse_notes.insert(0,f"Video Reference conditioning: persistent across all chunks, 24 fps, resolved={reference_video_source.target_width}x{reference_video_source.target_height}, frames={reference_video_source.frame_count}.")
         if reference_video_warning: reuse_notes.append(reference_video_warning)
@@ -211,9 +230,9 @@ def run_sequence(*,model:Any,clip:Any,video_vae:Any,audio_vae:Any,sampler:Any,si
     if context_diagnostics is not None:
         if entries:
             for reused_entry in entries:
-                _record_context_diagnostics(tracker=context_diagnostics,reports=sampling_reports,state=entry_to_state(reused_entry),continuity=continuity,reused=True)
+                _record_context_diagnostics(tracker=context_diagnostics,reports=sampling_reports,state=entry_to_state(reused_entry),continuity=continuity,reused=True,continuation_method=continuation_method,audio_continuity=audio_continuity,driving_audio_active=driving_audio_source is not None)
         elif previous_state is not None:
-            _record_context_diagnostics(tracker=context_diagnostics,reports=sampling_reports,state=previous_state,continuity=continuity,reused=True)
+            _record_context_diagnostics(tracker=context_diagnostics,reports=sampling_reports,state=previous_state,continuity=continuity,reused=True,continuation_method=continuation_method,audio_continuity=audio_continuity,driving_audio_active=driving_audio_source is not None)
     for sequence_index in range(len(entries),chunks):
         prompt=prompts[sequence_index]; prompt_hash_value=prompt_hashes[sequence_index]; is_final=sequence_index==chunks-1; effective_reroll_nonce=int(reroll_nonce) if int(reroll_from_chunk)>0 and sequence_index+1>=int(reroll_from_chunk) else 0; seed=derive_chunk_seed(base_seed,sequence_index,effective_reroll_nonce); motion_score=0.0; video_context=None; audio_context=None; context_before=None
         timeline_video_assets=reference_video_assets
@@ -226,36 +245,45 @@ def run_sequence(*,model:Any,clip:Any,video_vae:Any,audio_vae:Any,sampler:Any,si
             total_frames=initial_frame_count; latent=empty_h3_latent(width,height,total_frames); conditioning=attach_keyframes(chunk_cache[(prompt,bool(last_frame is not None and is_final))],frame_count=total_frames,first_latent=assets.first_latent,last_latent=assets.last_latent if is_final else None); clip_index=1; context_frames=0
             chunk_plan=make_plan(continuation=False,clip_index=clip_index,total_frames=total_frames,trim_frames=0,width=width,height=height,context_frames=5,state_capacity_frames=largest_context_capacity(total_frames),requested_extend_seconds=chunk_seconds,debug=debug); reason="initial clip"
         else:
-            context_frames,motion_score,reason=choose_context_frames(continuity,previous_state); desired_cumulative=int(round((sequence_index+1)*chunk_seconds*FPS)); requested_new_frames=max(1,desired_cumulative-retained_frames)
+            context_frames,motion_score,reason=choose_continuation_context_frames(method=continuation_method,continuity=continuity,state=previous_state,audio_continuity=bool(audio_continuity),driving_audio_active=driving_audio_source is not None); desired_cumulative=int(round((sequence_index+1)*chunk_seconds*FPS)); requested_new_frames=max(1,desired_cumulative-retained_frames)
             if is_final: shape=make_extension_shape_at_least(context_frames,requested_new_frames)
             else: shape=make_extension_shape(context_frames,requested_new_frames/FPS)
             latent=empty_h3_latent(width,height,shape.total_frames)
             base_conditioning=attach_keyframes(chunk_cache[(prompt,bool(last_frame is not None and is_final))],frame_count=shape.total_frames,first_latent=assets.first_latent,last_latent=assets.last_latent if is_final else None)
-            video_context,audio_context,grid_offset=select_context(previous_state,context_frames,include_audio=bool(audio_continuity)); context_before=context_fingerprint(video_context,audio_context)
-            conditioning=prepare_conditioning(base_conditioning,video_context=video_context,audio_context=audio_context,audio_grid_offset=grid_offset,context_frames=context_frames,new_frame_count=shape.total_frames,first_frame_policy=POLICY_REPLACE,preserve_last_frame=True)
+            # Driving Audio owns the audio timeline in both continuation modes.
+            # Do not feed the previous generated audio back as a second source.
+            carry_generated_audio=bool(audio_continuity) and driving_audio_source is None
+            video_context,audio_context,grid_offset=select_context(previous_state,context_frames,include_audio=carry_generated_audio); context_before=context_fingerprint(video_context,audio_context)
+            if continuation_method==CONTINUATION_NATIVE_MASKED:
+                latent=apply_native_masked_continuation(latent,video_context=video_context,audio_context=audio_context,context_frames=context_frames)
+                conditioning=prepare_masked_conditioning(base_conditioning,context_frames=context_frames,new_frame_count=shape.total_frames)
+            else:
+                conditioning=prepare_conditioning(base_conditioning,video_context=video_context,audio_context=audio_context,audio_grid_offset=grid_offset,context_frames=context_frames,new_frame_count=shape.total_frames,first_frame_policy=POLICY_REPLACE,preserve_last_frame=True)
             clip_index=int(previous_state["clip_index"])+1; chunk_plan=make_plan(continuation=True,clip_index=clip_index,total_frames=shape.total_frames,trim_frames=context_frames,width=width,height=height,context_frames=context_frames,state_capacity_frames=largest_context_capacity(shape.net_new_frames),requested_extend_seconds=chunk_seconds,debug=debug)
+            if continuation_method==CONTINUATION_NATIVE_MASKED: chunk_plan=plan_continuation_contract(chunk_plan,continuation_method)
         driving_audio_latent=slice_driving_audio_latent(driving_audio_assets,cumulative_retained_before=retained_frames,total_frames=int(chunk_plan["total_frames"]),trim_frames=int(chunk_plan["trim_frames"]),fps=FPS)
         conditioning=attach_driving_audio(conditioning,driving_audio_latent)
         chunk_model=clone_model_for_chunk(model,strict=bool(strict_compatibility),debug=bool(debug),chunk_index=clip_index,context_frames=context_frames if previous_state is not None else None)
         sampled=sample_chunk(model=chunk_model,conditioning=conditioning,latent=latent,sampler=sampler,sigmas=sigmas,seed=seed,enable_preview=bool(enable_preview))
         if context_before is not None and video_context is not None: assert_context_unchanged(video_context,audio_context,context_before)
         entry=make_chunk_entry(latent=sampled,plan=chunk_plan,prompt=prompt,prompt_hash=prompt_hash_value,seed=seed,context_frames=context_frames,motion_score=motion_score,reused=False); previous_state=entry_to_state(entry); entries.append(entry)
-        _record_context_diagnostics(tracker=context_diagnostics,reports=sampling_reports,state=previous_state,continuity=continuity,reused=False)
+        _record_context_diagnostics(tracker=context_diagnostics,reports=sampling_reports,state=previous_state,continuity=continuity,reused=False,continuation_method=continuation_method,audio_continuity=audio_continuity,driving_audio_active=driving_audio_source is not None)
         if storage_controller is not None: storage_controller.commit_chunk(entry, position=sequence_index)
         retained_frames+=int(chunk_plan["net_frames"])
-        sampling_reports.append(f"chunk {sequence_index+1}/{chunks}: seed={seed}, frames={chunk_plan['total_frames']}, trim={chunk_plan['trim_frames']}, retained_total={retained_frames}, context={context_frames} ({reason}), motion={motion_score:.6f}, "+(f"interop=emitted actual_prefix={CONTINUUM_ACTUAL_PREFIX_STEPS} consumer=not_observable" if context_before is not None else "interop=not_emitted"))
+        sampling_reports.append(f"chunk {sequence_index+1}/{chunks}: seed={seed}, frames={chunk_plan['total_frames']}, trim={chunk_plan['trim_frames']}, retained_total={retained_frames}, method={continuation_method}, context={context_frames} ({reason}), motion={motion_score:.6f}, "+(f"interop=emitted actual_prefix={CONTINUUM_ACTUAL_PREFIX_STEPS} consumer=not_observable" if context_before is not None else "interop=not_emitted"))
         del sampled,latent,conditioning,chunk_model,chunk_cache
         if timeline_video_source is not None and timeline_video_assets is not None: del timeline_video_assets
     if len(entries)!=chunks: raise SequenceRuntimeError(f"internal sequence length mismatch: expected {chunks}, got {len(entries)}")
     if latent_only:
         last_state=entry_to_state(entries[-1]); parent_id=session.get("session_id") if session is not None else None
-        settings={"continuity":continuity,"audio_continuity":bool(audio_continuity),"exact_total_duration":False,"prompt_mode":plan["mode"],"conditioning_mode":conditioning_mode,"base_seed":int(base_seed),"reroll_nonce":int(reroll_nonce),"diagnostics_mode":diagnostics_mode,"initial_state_source":initial_state is not None,"latent_first":True,"first_frame_hash":assets.first_frame_hash,"last_frame_hash":assets.last_frame_hash,"reference_contract":reference_assets.contract if reference_assets is not None else None}
+        settings={"continuity":continuity,"continuation_method":continuation_method,"audio_continuity":bool(audio_continuity),"exact_total_duration":False,"prompt_mode":plan["mode"],"conditioning_mode":conditioning_mode,"base_seed":int(base_seed),"reroll_nonce":int(reroll_nonce),"diagnostics_mode":diagnostics_mode,"initial_state_source":initial_state is not None,"latent_first":True,"first_frame_hash":assets.first_frame_hash,"last_frame_hash":assets.last_frame_hash,"reference_contract":reference_assets.contract if reference_assets is not None else None}
+        if continuation_method==CONTINUATION_NATIVE_MASKED: settings["native_mask_contract_version"]=NATIVE_MASK_CONTRACT_VERSION
         if reference_audio_source is not None: settings["reference_audio_contract"]=reference_audio_source.contract
         if driving_audio_source is not None: settings["driving_audio_contract"]=driving_audio_source.contract
         if reference_video_source is not None: settings["reference_video_contract"]=reference_video_source.contract
         if timeline_video_source is not None: settings["timeline_video_contract"]=timeline_video_source.contract
         new_session=make_session(chunks=entries,width=width,height=height,chunk_seconds=chunk_seconds,identity_hash=sequence_identity_hash,model_fingerprint_value=current_model_fingerprint,parent_session_id=parent_id,reroll_from_chunk=int(reroll_from_chunk),settings=settings)
-        report_lines=[f"H3 Continuum V3 {PACKAGE_VERSION}",f"Conditioning mode: {conditioning_mode_label(conditioning_mode)}.",prompt_plan_report(plan),"Decode: external ComfyUI Core VAE nodes; full raw AV chunks retained.",accelerators,"Execution: conditioning precomputed; single call-local MODEL clone per chunk; no internal VAE decode.",*reuse_notes]
+        report_lines=[f"H3 Continuum V3 {PACKAGE_VERSION}",f"Conditioning mode: {conditioning_mode_label(conditioning_mode)}.",f"Continuation: {continuation_method}.",prompt_plan_report(plan),"Decode: external ComfyUI Core VAE nodes; full raw AV chunks retained.",accelerators,"Execution: conditioning precomputed; single call-local MODEL clone per chunk; no internal VAE decode.",*reuse_notes]
         if diagnostics_mode!=DIAGNOSTICS_OFF: report_lines.extend(sampling_reports)
         report_lines.extend([session_summary(new_session),f"Output: {len(entries)} raw AV latent chunk(s); connect Core VAE Decode nodes, then H3 Continuum Assemble V3."])
         return entries,last_state,new_session,"\n".join(report_lines)
@@ -268,7 +296,8 @@ def run_sequence(*,model:Any,clip:Any,video_vae:Any,audio_vae:Any,sampler:Any,si
             raise SequenceRuntimeError(f"exact-duration sequence underflow: generated {int(images.shape[0])} frames for {target_frames}-frame target; refusing to repeat the final frame")
         images,audio,duration_report=enforce_total_frames(images,audio,target_frames=target_frames,preserve_final_frame=last_frame is not None)
     last_state=entry_to_state(entries[-1]); parent_id=session.get("session_id") if session is not None else None
-    settings={"continuity":continuity,"audio_continuity":bool(audio_continuity),"exact_total_duration":bool(exact_total_duration),"prompt_mode":plan["mode"],"base_seed":int(base_seed),"reroll_nonce":int(reroll_nonce),"diagnostics_mode":diagnostics_mode,"initial_state_source":initial_state is not None,"first_frame_hash":assets.first_frame_hash,"last_frame_hash":assets.last_frame_hash,"reference_contract":reference_assets.contract if reference_assets is not None else None}
+    settings={"continuity":continuity,"continuation_method":continuation_method,"audio_continuity":bool(audio_continuity),"exact_total_duration":bool(exact_total_duration),"prompt_mode":plan["mode"],"base_seed":int(base_seed),"reroll_nonce":int(reroll_nonce),"diagnostics_mode":diagnostics_mode,"initial_state_source":initial_state is not None,"first_frame_hash":assets.first_frame_hash,"last_frame_hash":assets.last_frame_hash,"reference_contract":reference_assets.contract if reference_assets is not None else None}
+    if continuation_method==CONTINUATION_NATIVE_MASKED: settings["native_mask_contract_version"]=NATIVE_MASK_CONTRACT_VERSION
     new_session=make_session(chunks=entries,width=width,height=height,chunk_seconds=chunk_seconds,identity_hash=sequence_identity_hash,model_fingerprint_value=current_model_fingerprint,parent_session_id=parent_id,reroll_from_chunk=int(reroll_from_chunk),settings=settings)
     decoded_gib=float(images.shape[0])*float(width)*float(height)*3.0*4.0/(1024.0**3)
     report_lines=[f"H3 Continuum V2 {PACKAGE_VERSION}",prompt_plan_report(plan),f"Seam correction: {seam_correction}.",accelerators,"Execution: conditioning precomputed; single call-local MODEL clone per chunk; decode deferred until sampling completed.",*reuse_notes]

--- a/v2/sequence.py
+++ b/v2/sequence.py
@@ -24,7 +24,7 @@ from ..driving_audio import (
 )
 from ..model_patch import clone_model_for_chunk
 from ..state import assert_context_unchanged, context_fingerprint, make_plan, select_context, validate_state
-from ..temporal import align_frame_count_up, largest_context_capacity, make_extension_shape
+from ..temporal import align_frame_count_up, largest_context_capacity, make_extension_shape, make_extension_shape_at_least
 from ..version import PACKAGE_VERSION
 from .decoder import decode_sequence, decode_sequence_with_seam, enforce_total_frames
 from .context_diagnostics import ContextDiagnosticsTracker
@@ -73,14 +73,20 @@ def _preserved_prefix(*,session,prompt_hashes,chunks,reroll_from_chunk,width,hei
     if reroll_from_chunk<0 or reroll_from_chunk>chunks: raise SessionValidationError("reroll_from_chunk must be 0 or a valid one-based chunk index")
     limit=min(len(session["chunks"]),chunks)
     if reroll_from_chunk>0: limit=min(limit,reroll_from_chunk-1)
-    preserved=[]
+    preserved=[]; retained_frames=0
     for index in range(limit):
         try: entry=validate_chunk_entry(session["chunks"][index])
         except SessionValidationError as exc:
             notes.append(f"session reuse stopped before chunk {index+1}: stored chunk was rejected ({exc})")
             break
         if entry["prompt_hash"]!=prompt_hashes[index]: notes.append(f"session reuse stopped before chunk {index+1}: prompt changed"); break
-        preserved.append(_clone_entry_for_reuse(entry))
+        candidate_retained=retained_frames+int(entry["plan"]["net_frames"])
+        if index==chunks-1:
+            target_frames=int(round((index+1)*float(chunk_seconds)*FPS))
+            if candidate_retained<target_frames:
+                notes.append(f"session reuse stopped before chunk {index+1}: stored sequence retained {candidate_retained} frames for {target_frames}-frame target")
+                break
+        preserved.append(_clone_entry_for_reuse(entry)); retained_frames=candidate_retained
     if reroll_from_chunk==0 and len(preserved)==min(len(session["chunks"]),chunks):
         notes.append(f"resuming after accepted chunk {len(session['chunks'])}" if len(session["chunks"])<chunks else "all requested chunks reused from the session")
     elif reroll_from_chunk>0: notes.append(f"preserved chunks 1-{len(preserved)}; regenerated from chunk {reroll_from_chunk}")
@@ -220,7 +226,10 @@ def run_sequence(*,model:Any,clip:Any,video_vae:Any,audio_vae:Any,sampler:Any,si
             total_frames=initial_frame_count; latent=empty_h3_latent(width,height,total_frames); conditioning=attach_keyframes(chunk_cache[(prompt,bool(last_frame is not None and is_final))],frame_count=total_frames,first_latent=assets.first_latent,last_latent=assets.last_latent if is_final else None); clip_index=1; context_frames=0
             chunk_plan=make_plan(continuation=False,clip_index=clip_index,total_frames=total_frames,trim_frames=0,width=width,height=height,context_frames=5,state_capacity_frames=largest_context_capacity(total_frames),requested_extend_seconds=chunk_seconds,debug=debug); reason="initial clip"
         else:
-            context_frames,motion_score,reason=choose_context_frames(continuity,previous_state); desired_cumulative=int(round((sequence_index+1)*chunk_seconds*FPS)); requested_new_frames=max(1,desired_cumulative-retained_frames); shape=make_extension_shape(context_frames,requested_new_frames/FPS); latent=empty_h3_latent(width,height,shape.total_frames)
+            context_frames,motion_score,reason=choose_context_frames(continuity,previous_state); desired_cumulative=int(round((sequence_index+1)*chunk_seconds*FPS)); requested_new_frames=max(1,desired_cumulative-retained_frames)
+            if is_final: shape=make_extension_shape_at_least(context_frames,requested_new_frames)
+            else: shape=make_extension_shape(context_frames,requested_new_frames/FPS)
+            latent=empty_h3_latent(width,height,shape.total_frames)
             base_conditioning=attach_keyframes(chunk_cache[(prompt,bool(last_frame is not None and is_final))],frame_count=shape.total_frames,first_latent=assets.first_latent,last_latent=assets.last_latent if is_final else None)
             video_context,audio_context,grid_offset=select_context(previous_state,context_frames,include_audio=bool(audio_continuity)); context_before=context_fingerprint(video_context,audio_context)
             conditioning=prepare_conditioning(base_conditioning,video_context=video_context,audio_context=audio_context,audio_grid_offset=grid_offset,context_frames=context_frames,new_frame_count=shape.total_frames,first_frame_policy=POLICY_REPLACE,preserve_last_frame=True)
@@ -254,7 +263,10 @@ def run_sequence(*,model:Any,clip:Any,video_vae:Any,audio_vae:Any,sampler:Any,si
     else: images,audio,decode_reports=decode_sequence_with_seam(entries=entries,video_vae=video_vae,audio_vae=audio_vae,diagnostics_mode=diagnostics_mode,automatic=seam_correction==SEAM_CORRECTION_AUTO)
     duration_report=""
     if exact_total_duration:
-        target_frames=int(round(chunks*chunk_seconds*FPS)); images,audio,duration_report=enforce_total_frames(images,audio,target_frames=target_frames,preserve_final_frame=last_frame is not None)
+        target_frames=int(round(chunks*chunk_seconds*FPS))
+        if int(images.shape[0])<target_frames:
+            raise SequenceRuntimeError(f"exact-duration sequence underflow: generated {int(images.shape[0])} frames for {target_frames}-frame target; refusing to repeat the final frame")
+        images,audio,duration_report=enforce_total_frames(images,audio,target_frames=target_frames,preserve_final_frame=last_frame is not None)
     last_state=entry_to_state(entries[-1]); parent_id=session.get("session_id") if session is not None else None
     settings={"continuity":continuity,"audio_continuity":bool(audio_continuity),"exact_total_duration":bool(exact_total_duration),"prompt_mode":plan["mode"],"base_seed":int(base_seed),"reroll_nonce":int(reroll_nonce),"diagnostics_mode":diagnostics_mode,"initial_state_source":initial_state is not None,"first_frame_hash":assets.first_frame_hash,"last_frame_hash":assets.last_frame_hash,"reference_contract":reference_assets.contract if reference_assets is not None else None}
     new_session=make_session(chunks=entries,width=width,height=height,chunk_seconds=chunk_seconds,identity_hash=sequence_identity_hash,model_fingerprint_value=current_model_fingerprint,parent_session_id=parent_id,reroll_from_chunk=int(reroll_from_chunk),settings=settings)

--- a/v3/assembly.py
+++ b/v3/assembly.py
@@ -32,6 +32,17 @@ VIDEO_SEAM_ANALYSIS_OPTIONS = (
     VIDEO_SEAM_ANALYZE,
     VIDEO_SEAM_OFF,
 )
+IMAGE_OUTPUT_AUTO = "Auto"
+IMAGE_OUTPUT_CUDA = "CUDA"
+IMAGE_OUTPUT_CPU = "CPU"
+IMAGE_OUTPUT_DEVICE_OPTIONS = (
+    IMAGE_OUTPUT_AUTO,
+    IMAGE_OUTPUT_CUDA,
+    IMAGE_OUTPUT_CPU,
+)
+_GIB = 1024**3
+_AUTO_CUDA_MIN_HEADROOM = 2 * _GIB
+_AUTO_CUDA_HEADROOM_FRACTION = 0.10
 
 
 def _singleton(value: Any, name: str) -> Any:
@@ -57,6 +68,109 @@ def _format_elapsed(seconds: float) -> str:
     return f"{int(hours):02d}:{int(minutes):02d}:{seconds:05.2f}"
 
 
+def _tensor_nbytes(shape: tuple[int, ...], dtype: torch.dtype) -> int:
+    elements = 1
+    for dimension in shape:
+        elements *= int(dimension)
+    return elements * torch.empty((), dtype=dtype).element_size()
+
+
+def _resolve_image_output_device(
+    images: list[Any],
+    output_shape: tuple[int, int, int, int],
+    preference: str,
+) -> torch.device:
+    preference = str(preference)
+    if preference not in IMAGE_OUTPUT_DEVICE_OPTIONS:
+        raise ValueError(f"unknown Image Output Device: {preference!r}")
+    if preference == IMAGE_OUTPUT_CPU:
+        return torch.device("cpu")
+
+    if not torch.cuda.is_available():
+        if preference == IMAGE_OUTPUT_CUDA:
+            raise RuntimeError("Image Output Device CUDA requires CUDA")
+        return torch.device("cpu")
+
+    first_tensor = next((item for item in images if torch.is_tensor(item)), None)
+    if first_tensor is None:
+        raise ValueError("decoded images contain no IMAGE tensors")
+    cuda_device = (
+        first_tensor.device
+        if first_tensor.device.type == "cuda"
+        else torch.device("cuda")
+    )
+    if preference == IMAGE_OUTPUT_CUDA:
+        return cuda_device
+
+    # Auto always checks the new output allocation against currently free VRAM,
+    # including when decoded inputs themselves are already resident on CUDA.
+    try:
+        free_bytes, total_bytes = torch.cuda.mem_get_info(cuda_device)
+    except Exception:
+        return torch.device("cpu")
+
+    output_bytes = _tensor_nbytes(output_shape, first_tensor.dtype)
+    frame_bytes = _tensor_nbytes(output_shape[1:], first_tensor.dtype)
+    headroom = max(
+        _AUTO_CUDA_MIN_HEADROOM,
+        int(total_bytes * _AUTO_CUDA_HEADROOM_FRACTION),
+    )
+    if free_bytes >= output_bytes + frame_bytes + headroom:
+        return cuda_device
+    return torch.device("cpu")
+
+
+def _apply_video_patch(
+    image_buffer: torch.Tensor,
+    *,
+    frame_start: int,
+    net_frames: int,
+    patch: torch.Tensor | None,
+) -> None:
+    if patch is None:
+        return
+    if not torch.is_tensor(patch) or patch.ndim != 4:
+        raise ValueError("video seam patch must be an IMAGE tensor [frames,H,W,C]")
+    patch_frames = int(patch.shape[0])
+    if patch_frames < 1 or patch_frames > int(net_frames):
+        raise ValueError("video seam patch frame count is outside the retained segment")
+    if tuple(patch.shape[1:]) != tuple(image_buffer.shape[1:]):
+        raise ValueError("video seam patch geometry changed at assembly")
+    image_buffer[frame_start : frame_start + patch_frames].copy_(
+        patch.to(device=image_buffer.device, dtype=image_buffer.dtype)
+    )
+
+
+def _enforce_image_duration_in_place(
+    image_buffer: torch.Tensor,
+    *,
+    current_frames: int,
+    target_frames: int,
+    preserve_final_frame: bool,
+) -> torch.Tensor:
+    """Apply exact-duration image trim/pad inside the already-owned output buffer."""
+    current_frames = int(current_frames)
+    target_frames = int(target_frames)
+    if target_frames < 1:
+        raise ValueError("target_frames must be positive")
+    if current_frames < 1:
+        raise ValueError("cannot adjust an empty image sequence")
+    if int(image_buffer.shape[0]) < max(current_frames, target_frames):
+        raise ValueError("image output buffer has insufficient exact-duration capacity")
+
+    adjustment = target_frames - current_frames
+    if adjustment < 0:
+        if preserve_final_frame and target_frames >= 2:
+            image_buffer[target_frames - 1].copy_(image_buffer[current_frames - 1])
+    elif adjustment > 0:
+        image_buffer[current_frames:target_frames].copy_(
+            image_buffer[current_frames - 1 : current_frames].expand(
+                adjustment, *image_buffer.shape[1:]
+            )
+        )
+    return image_buffer[:target_frames]
+
+
 def assemble_decoded_chunks(
     *,
     images: list[Any],
@@ -65,6 +179,8 @@ def assemble_decoded_chunks(
     exact_total_duration: bool,
     audio_seam: str,
     diagnostics: str,
+    image_output_device: str = IMAGE_OUTPUT_AUTO,
+    video_patches: dict[int, torch.Tensor] | None = None,
 ):
     plan = validate_assembly_plan(assembly_plan)
     diagnostics_mode = normalize_diagnostics_mode(diagnostics)
@@ -79,6 +195,12 @@ def assemble_decoded_chunks(
         )
 
     total_retained_frames = sum(int(item["net_frames"]) for item in chunk_plans)
+    target_frames = int(plan["target_frames"])
+    image_capacity_frames = (
+        max(total_retained_frames, target_frames)
+        if exact_total_duration
+        else total_retained_frames
+    )
     image_buffer = None
     audio_buffer = None
     audio_rate = None
@@ -87,13 +209,14 @@ def assemble_decoded_chunks(
         "H3 Continuum Assemble V3",
         f"Audio Seam: {audio_seam}. Video seam correction is disabled.",
     ]
+    video_patches = video_patches or {}
 
     for index, (raw_images, raw_audio, chunk) in enumerate(
         zip(images, audio, chunk_plans), start=1
     ):
         if not torch.is_tensor(raw_images) or raw_images.ndim != 4:
             raise ValueError(f"decoded image chunk {index} must be [frames,H,W,C]")
-        raw_images = raw_images.detach().to("cpu")
+        raw_images = raw_images.detach()
         total_frames = int(chunk["total_frames"])
         trim_frames = int(chunk["trim_frames"])
         net_frames = int(chunk["net_frames"])
@@ -102,7 +225,7 @@ def assemble_decoded_chunks(
                 f"decoded image chunk {index} has {raw_images.shape[0]} frames; "
                 f"expected at least {total_frames}"
             )
-        segment_images = raw_images[:total_frames][trim_frames:].contiguous()
+        segment_images = raw_images[:total_frames][trim_frames:]
         if int(segment_images.shape[0]) != net_frames:
             raise ValueError(
                 f"decoded image chunk {index} retained {segment_images.shape[0]} frames; "
@@ -129,14 +252,48 @@ def assemble_decoded_chunks(
         )
 
         if image_buffer is None:
-            image_buffer = torch.empty(
-                (total_retained_frames, *segment_images.shape[1:]),
-                dtype=segment_images.dtype,
-                device="cpu",
+            output_shape = (
+                image_capacity_frames,
+                int(segment_images.shape[1]),
+                int(segment_images.shape[2]),
+                int(segment_images.shape[3]),
             )
+            output_device = _resolve_image_output_device(
+                images,
+                output_shape,
+                image_output_device,
+            )
+            image_buffer = torch.empty(
+                output_shape,
+                dtype=segment_images.dtype,
+                device=output_device,
+            )
+            if diagnostics_mode == DIAGNOSTICS_FULL:
+                actual_height = int(segment_images.shape[1])
+                actual_width = int(segment_images.shape[2])
+                plan_width = int(plan["width"])
+                plan_height = int(plan["height"])
+                scale_x = actual_width / float(plan_width)
+                scale_y = actual_height / float(plan_height)
+                output_mib = _tensor_nbytes(output_shape, segment_images.dtype) / (1024**2)
+                reports.append(
+                    "Decoded geometry: "
+                    f"{actual_width}x{actual_height} vs plan {plan_width}x{plan_height} "
+                    f"({scale_x:.3f}x/{scale_y:.3f}x); image buffer "
+                    f"{image_capacity_frames} frames, {output_mib:.1f} MiB on {output_device}."
+                )
         elif tuple(segment_images.shape[1:]) != tuple(image_buffer.shape[1:]):
             raise ValueError(f"decoded image geometry changed at chunk {index}")
+
+        # copy_ supports CPU<->CUDA directly, so do not first materialize a full
+        # retained-chunk CUDA temporary with segment_images.to(device=...).
         image_buffer[frame_cursor:frame_stop].copy_(segment_images)
+        _apply_video_patch(
+            image_buffer,
+            frame_start=frame_cursor,
+            net_frames=net_frames,
+            patch=video_patches.get(index - 1),
+        )
 
         if audio_buffer is None:
             audio_buffer = torch.empty(
@@ -203,22 +360,39 @@ def assemble_decoded_chunks(
             f"V3 assembly cursor mismatch: {frame_cursor} != {total_retained_frames}"
         )
 
+    result_images = image_buffer[:total_retained_frames]
     result_audio = {
         "waveform": audio_buffer.contiguous(),
         "sample_rate": audio_rate,
     }
     duration_report = ""
     if exact_total_duration:
-        image_buffer, result_audio, duration_report = enforce_total_frames(
-            image_buffer.contiguous(),
-            result_audio,
-            target_frames=int(plan["target_frames"]),
-            preserve_final_frame=bool(plan.get("preserve_final_frame")),
+        preserve_final_frame = bool(plan.get("preserve_final_frame"))
+        result_images = _enforce_image_duration_in_place(
+            image_buffer,
+            current_frames=total_retained_frames,
+            target_frames=target_frames,
+            preserve_final_frame=preserve_final_frame,
         )
+        # Reuse the existing, validated audio exact-duration policy with a tiny
+        # placeholder image tensor. This keeps identical audio trim/pad semantics
+        # without making enforce_total_frames allocate another full video tensor.
+        duration_probe = torch.empty(
+            (total_retained_frames, 1, 1, 1),
+            dtype=torch.uint8,
+            device="cpu",
+        )
+        _, result_audio, duration_report = enforce_total_frames(
+            duration_probe,
+            result_audio,
+            target_frames=target_frames,
+            preserve_final_frame=preserve_final_frame,
+        )
+        del duration_probe
 
     reports.append(
         f"Assembled {len(chunk_plans)} externally decoded chunks into "
-        f"{image_buffer.shape[0]} frames with cumulative sample-boundary alignment."
+        f"{result_images.shape[0]} frames with cumulative sample-boundary alignment."
     )
     if duration_report:
         reports.append(duration_report)
@@ -227,7 +401,7 @@ def assemble_decoded_chunks(
         elapsed = time.perf_counter() - float(runtime_started_at)
         if math.isfinite(elapsed) and elapsed >= 0.0:
             reports.append(f"Total workflow elapsed: {_format_elapsed(elapsed)}")
-    return image_buffer.contiguous(), result_audio, "\n".join(reports)
+    return result_images.contiguous(), result_audio, "\n".join(reports)
 
 
 class H3ContinuumAssembleV3:
@@ -269,6 +443,18 @@ class H3ContinuumAssembleV3:
                         "display_name": "Report Detail",
                     },
                 ),
+                "image_output_device": (
+                    IMAGE_OUTPUT_DEVICE_OPTIONS,
+                    {
+                        "default": IMAGE_OUTPUT_AUTO,
+                        "display_name": "Image Output Device",
+                        "tooltip": (
+                            "Auto keeps the assembled IMAGE in VRAM when the full output plus "
+                            "conservative headroom fits. CUDA is useful after high-resolution "
+                            "latent upscaling because it avoids a second full-video CPU buffer."
+                        ),
+                    },
+                ),
             }
         }
 
@@ -286,6 +472,7 @@ class H3ContinuumAssembleV3:
         exact_total_duration,
         audio_seam,
         diagnostics,
+        image_output_device=IMAGE_OUTPUT_AUTO,
     ):
         return assemble_decoded_chunks(
             images=_chunk_list(images),
@@ -296,7 +483,12 @@ class H3ContinuumAssembleV3:
             ),
             audio_seam=str(_singleton(audio_seam, "audio_seam")),
             diagnostics=str(_singleton(diagnostics, "diagnostics")),
+            image_output_device=str(
+                _singleton(image_output_device, "image_output_device")
+            ),
         )
+
+
 # V3.0.1 hardening integration: preflight before allocation; Detailed Report only.
 from ..hardening import assemble_with_hardening as _assemble_with_hardening
 
@@ -320,6 +512,7 @@ class H3ContinuumAssembleSeamExperimental(H3ContinuumAssembleV3):
         schema = super().INPUT_TYPES()
         required = dict(schema["required"])
         diagnostics = required.pop("diagnostics")
+        image_output_device = required.pop("image_output_device")
         required["video_seam"] = (
             VIDEO_SEAM_ANALYSIS_OPTIONS,
             {
@@ -333,6 +526,7 @@ class H3ContinuumAssembleSeamExperimental(H3ContinuumAssembleV3):
             },
         )
         required["diagnostics"] = diagnostics
+        required["image_output_device"] = image_output_device
         schema["required"] = required
         return schema
 
@@ -345,6 +539,7 @@ class H3ContinuumAssembleSeamExperimental(H3ContinuumAssembleV3):
         audio_seam,
         video_seam,
         diagnostics,
+        image_output_device=IMAGE_OUTPUT_AUTO,
     ):
         mode = str(_singleton(video_seam, "video_seam"))
         if mode not in VIDEO_SEAM_ANALYSIS_OPTIONS:
@@ -357,6 +552,7 @@ class H3ContinuumAssembleSeamExperimental(H3ContinuumAssembleV3):
                 exact_total_duration,
                 audio_seam,
                 diagnostics,
+                image_output_device=image_output_device,
             )
 
         image_chunks = _chunk_list(images)
@@ -364,10 +560,11 @@ class H3ContinuumAssembleSeamExperimental(H3ContinuumAssembleV3):
         analyses = []
         analysis_error = None
         actions = {}
+        video_patches = {}
         try:
             from .video_seam import (
                 analyze_decoded_boundaries,
-                correct_decoded_boundaries,
+                build_decoded_boundary_patches,
                 format_video_boundary_analysis,
             )
 
@@ -376,7 +573,7 @@ class H3ContinuumAssembleSeamExperimental(H3ContinuumAssembleV3):
                 assembly_plan=plan,
             )
             if mode in (VIDEO_SEAM_AUTO, VIDEO_SEAM_AUTO_2):
-                image_chunks, actions = correct_decoded_boundaries(
+                video_patches, actions = build_decoded_boundary_patches(
                     images=image_chunks,
                     assembly_plan=plan,
                     analyses=analyses,
@@ -384,6 +581,7 @@ class H3ContinuumAssembleSeamExperimental(H3ContinuumAssembleV3):
                 )
         except Exception as exc:
             analysis_error = exc
+            video_patches = {}
 
         result_images, result_audio, report = assemble_decoded_chunks(
             images=image_chunks,
@@ -394,6 +592,10 @@ class H3ContinuumAssembleSeamExperimental(H3ContinuumAssembleV3):
             ),
             audio_seam=str(_singleton(audio_seam, "audio_seam")),
             diagnostics=str(_singleton(diagnostics, "diagnostics")),
+            image_output_device=str(
+                _singleton(image_output_device, "image_output_device")
+            ),
+            video_patches=video_patches,
         )
         if mode == VIDEO_SEAM_ANALYZE:
             status = "Video Seam: Analyze Only; decoded frames and audio are unchanged."

--- a/v3/driving_nodes.py
+++ b/v3/driving_nodes.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 import torch
 
-from ..constants import FPS
+from ..constants import FPS, V2_CONTINUITY_OPTIONS
 from ..driving_audio import prepare_driving_audio_source
+from ..masked_continuation import (
+    CONTINUATION_METHODS,
+    CONTINUATION_NATIVE_MASKED,
+    continuation_method_scope,
+    validate_native_masked_request,
+)
 from ..reference import bundle_reference_images
 from ..reference_video import (
     REFERENCE_VIDEO_SIZE_EFFICIENT,
@@ -17,6 +23,29 @@ from .nodes import CATEGORY as CONTINUUM_CATEGORY, H3ContinuumSamplerProduction
 
 
 _DRIVING_AUDIO_PLAN_KEY = "_h3_continuum_driving_audio_v1"
+V34_CONTINUITY_STRONG = "Strong — 39 frames"
+V34_CONTINUITY_OPTIONS = (
+    V2_CONTINUITY_OPTIONS[0],
+    V2_CONTINUITY_OPTIONS[1],
+    V2_CONTINUITY_OPTIONS[2],
+    V34_CONTINUITY_STRONG,
+    V2_CONTINUITY_OPTIONS[3],
+)
+
+
+def _normalize_v34_continuity(value: str) -> str:
+    """Map the V3.4 display value onto the inherited sequence wire contract.
+
+    V2/V3.3 keep the historical ``Strong — 39 frames (Experimental)`` value.
+    V3.4 promotes that exact 39-frame boundary, so its public widget uses the
+    unsuffixed label while still accepting the old serialized value as an API
+    compatibility alias.
+    """
+
+    value = str(value)
+    if value == V34_CONTINUITY_STRONG:
+        return V2_CONTINUITY_OPTIONS[3]
+    return value
 
 
 def _unwrap_single_audio_value(value):
@@ -52,17 +81,18 @@ def _driving_audio_from_plan(args, kwargs):
 
 
 class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
-    """V3.4 sampler with globally encoded, absolute-time Driving Audio."""
+    """V3.4 sampler with native masked continuation and Driving Audio."""
 
     DEPRECATED = False
     CATEGORY = CONTINUUM_CATEGORY
     DESCRIPTION = (
-        "H3 Continuum V3.4 with optional Driving Audio and persistent Video Reference. "
-        "Video Reference uses an IMAGE frame batch and one-chunk reference prefix."
+        "H3 Continuum V3.4 with native masked AV continuation by default, optional "
+        "Guide / Motion Context continuation, Driving Audio, and persistent Video Reference."
     )
     SEARCH_ALIASES = [
         "H3 Continuum Sampler V3.4",
         "MiniMax H3 Driving Audio",
+        "MiniMax H3 masked continuation",
     ]
     RETURN_TYPES = (
         "LATENT",
@@ -84,6 +114,22 @@ class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
     def INPUT_TYPES(cls):
         schema = super().INPUT_TYPES()
         required = dict(schema.get("required", {}))
+        # Keep the inherited key position stable for saved workflows while making
+        # the new exact-AV default internally valid. 39 video frames map exactly
+        # to 65 H3 audio-latent steps at 24 fps / 40 Hz. The final legacy value
+        # remains accepted for headless/serialized V3.4 compatibility; v34_ui.js
+        # presents only the canonical unsuffixed V3.4 value.
+        required["continuity"] = (
+            V34_CONTINUITY_OPTIONS,
+            {
+                "default": V34_CONTINUITY_STRONG,
+                "tooltip": (
+                    "Protected previous-chunk context. Native Masked generated-audio "
+                    "continuation requires the exact 39-frame AV boundary; video-only "
+                    "continuation and Guide / Motion Context also support 5 or 22 frames."
+                ),
+            },
+        )
         required["video_reference_size"] = (
             REFERENCE_VIDEO_SIZE_OPTIONS,
             {
@@ -93,6 +139,21 @@ class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
                     "Efficient limits Video Reference to about 0.4 MP; Balanced uses "
                     "about 0.6 MP; Match Output uses the output pixel area. Source "
                     "aspect ratio is preserved and smaller sources are not enlarged."
+                ),
+            },
+        )
+        # Appending this widget avoids shifting existing V3.4 serialized widget
+        # positions. New nodes receive the Native default; v34_ui.js migrates
+        # saved graphs without this widget to Guide / Motion Context.
+        required["continuation_method"] = (
+            CONTINUATION_METHODS,
+            {
+                "default": CONTINUATION_NATIVE_MASKED,
+                "display_name": "Continuation Method",
+                "tooltip": (
+                    "Native Masked preserves the previous generated H3 latent directly "
+                    "inside the next target and is recommended for exact same-shot continuation. "
+                    "Guide / Motion Context keeps the previous clip as softer H3 guide context."
                 ),
             },
         )
@@ -139,10 +200,29 @@ class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
         audio_vae=None,
         reference_video_1=None,
         video_reference_size=REFERENCE_VIDEO_SIZE_EFFICIENT,
+        continuation_method=CONTINUATION_NATIVE_MASKED,
         **kwargs,
     ):
         from ..reference_video import prepare_reference_video_source
         from ..temporal import align_frame_count_up
+
+        # Validate the cross-modal continuation contract before any VAE/model
+        # preparation. Old or manually edited workflows may still serialize a
+        # 5/22-frame profile alongside Native Masked + generated Audio Continuity;
+        # discovering that only when chunk 2 starts wastes a complete chunk 1.
+        continuity = _normalize_v34_continuity(
+            kwargs.get("continuity", V34_CONTINUITY_STRONG)
+        )
+        validate_native_masked_request(
+            method=continuation_method,
+            continuity=continuity,
+            audio_continuity=bool(kwargs.get("audio_continuity", True)),
+            driving_audio_active=driving_audio is not None,
+            chunks=int(kwargs.get("chunks", 1)),
+        )
+        # The inherited V2/V3.3 sequence engine intentionally keeps its stable
+        # historical wire value. Normalize only at this V3.4 facade boundary.
+        kwargs["continuity"] = continuity
 
         active_reference = any(
             kwargs.get(f"reference_image_{index}") is not None
@@ -182,14 +262,15 @@ class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
             output_height=int(kwargs["height"]),
             size_mode=str(video_reference_size),
         )
-        outputs = super().run(
-            reference_audio_1=None,
-            reference_audio_vae=None,
-            driving_audio_source=source,
-            driving_audio_vae=audio_vae,
-            reference_video_source=reference_video_source,
-            **kwargs,
-        )
+        with continuation_method_scope(continuation_method):
+            outputs = super().run(
+                reference_audio_1=None,
+                reference_audio_vae=None,
+                driving_audio_source=source,
+                driving_audio_vae=audio_vae,
+                reference_video_source=reference_video_source,
+                **kwargs,
+            )
         selected_audio = _copy_audio(source.source_audio) if source is not None else None
         if selected_audio is not None and len(outputs) >= 3 and isinstance(outputs[2], dict):
             assembly_plan = dict(outputs[2])

--- a/v3/driving_nodes.py
+++ b/v3/driving_nodes.py
@@ -87,7 +87,8 @@ class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
     CATEGORY = CONTINUUM_CATEGORY
     DESCRIPTION = (
         "H3 Continuum V3.4 with native masked AV continuation by default, optional "
-        "Guide / Motion Context continuation, Driving Audio, and persistent Video Reference."
+        "Guide / Motion Context continuation, hybrid First/Last + Reference Image "
+        "conditioning, Driving Audio, and persistent Video Reference."
     )
     SEARCH_ALIASES = [
         "H3 Continuum Sampler V3.4",
@@ -224,16 +225,11 @@ class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
         # historical wire value. Normalize only at this V3.4 facade boundary.
         kwargs["continuity"] = continuity
 
-        active_reference = any(
-            kwargs.get(f"reference_image_{index}") is not None
-            for index in range(1, 9)
-        )
-        if active_reference:
-            # V3.4 follows Core-style mode precedence: Reference mode wins over
-            # connected First/Last inputs rather than rejecting the combination.
-            kwargs["first_frame"] = None
-            kwargs["last_frame"] = None
-
+        # Reference blocks and First/Last keyframes are orthogonal Core H3
+        # conditioning. Do not discard First/Last when references are connected:
+        # the inherited sequence engine encodes ref2va presentation first and
+        # layers keyframe latents on that conditioning, matching Core's
+        # Reference-to-Video + Add Guide composition.
         extra_references = [
             kwargs.pop(f"reference_image_{index}", None)
             for index in range(4, 9)

--- a/v3/driving_nodes.py
+++ b/v3/driving_nodes.py
@@ -6,6 +6,7 @@ import torch
 
 from ..constants import FPS
 from ..driving_audio import prepare_driving_audio_source
+from ..reference import bundle_reference_images
 from ..reference_video import (
     REFERENCE_VIDEO_SIZE_EFFICIENT,
     REFERENCE_VIDEO_SIZE_OPTIONS,
@@ -98,6 +99,8 @@ class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
         optional = dict(schema.get("optional", {}))
         optional.pop("reference_audio_1", None)
         optional.pop("reference_audio_vae", None)
+        for index in range(4, 9):
+            optional[f"reference_image_{index}"] = ("IMAGE",)
         optional["reference_video_1"] = (
             "IMAGE",
             {
@@ -140,6 +143,26 @@ class H3ContinuumSamplerV34(H3ContinuumSamplerProduction):
     ):
         from ..reference_video import prepare_reference_video_source
         from ..temporal import align_frame_count_up
+
+        active_reference = any(
+            kwargs.get(f"reference_image_{index}") is not None
+            for index in range(1, 9)
+        )
+        if active_reference:
+            # V3.4 follows Core-style mode precedence: Reference mode wins over
+            # connected First/Last inputs rather than rejecting the combination.
+            kwargs["first_frame"] = None
+            kwargs["last_frame"] = None
+
+        extra_references = [
+            kwargs.pop(f"reference_image_{index}", None)
+            for index in range(4, 9)
+        ]
+        if any(image is not None for image in extra_references):
+            kwargs["reference_image_3"] = bundle_reference_images(
+                kwargs.get("reference_image_3"),
+                *extra_references,
+            )
 
         target_frames = round(
             int(kwargs["chunks"]) * float(kwargs["chunk_seconds"]) * FPS

--- a/v3/plan.py
+++ b/v3/plan.py
@@ -89,12 +89,14 @@ def validate_assembly_plan(plan: Any) -> dict[str, Any]:
         raise AssemblyPlanError("assembly plan dimensions are invalid")
     if float(plan.get("chunk_seconds", 0.0)) <= 0:
         raise AssemblyPlanError("assembly plan chunk duration is invalid")
-    if int(plan.get("target_frames", 0)) <= 0:
+    target_frames = int(plan.get("target_frames", 0))
+    if target_frames <= 0:
         raise AssemblyPlanError("assembly plan target frame count is invalid")
 
     chunks = plan.get("chunks")
     if not isinstance(chunks, list) or not chunks:
         raise AssemblyPlanError("assembly plan contains no chunks")
+    natural_frames = 0
     for expected_index, chunk in enumerate(chunks, start=1):
         if not isinstance(chunk, dict):
             raise AssemblyPlanError(f"assembly chunk {expected_index} is invalid")
@@ -107,6 +109,7 @@ def validate_assembly_plan(plan: Any) -> dict[str, Any]:
             raise AssemblyPlanError(
                 f"assembly chunk {expected_index} frame plan is invalid"
             )
+        natural_frames += net
         if int(chunk.get("context_frames", -1)) < 0:
             raise AssemblyPlanError(
                 f"assembly chunk {expected_index} context is invalid"
@@ -119,6 +122,11 @@ def validate_assembly_plan(plan: Any) -> dict[str, Any]:
             raise AssemblyPlanError(
                 f"assembly chunk {expected_index} audio latent length is invalid"
             )
+    if natural_frames < target_frames:
+        raise AssemblyPlanError(
+            f"assembly plan retains {natural_frames} frames for a {target_frames}-frame target; "
+            "regenerate the final chunk instead of padding the last frame"
+        )
     return plan
 # V3.0.1 hardening integration: redundant metadata plus fail-closed validation.
 from ..hardening import (

--- a/v3/video_seam.py
+++ b/v3/video_seam.py
@@ -418,31 +418,44 @@ def analyze_decoded_boundaries(
     return analyses
 
 
-def correct_decoded_boundaries(
+def _correction_kind_and_count(
+    analysis: VideoBoundaryAnalysis,
+    *,
+    enable_exposure_ramp: bool,
+) -> tuple[str, int]:
+    correction_kind = "transient flash"
+    replace_frames = int(analysis.recommended_rewind)
+    if analysis.micro_flash_candidate:
+        correction_kind = "micro-flash"
+        replace_frames = 1
+    elif enable_exposure_ramp and analysis.exposure_ramp_candidate:
+        correction_kind = "exposure ramp"
+        replace_frames = 4
+    return correction_kind, replace_frames
+
+
+def build_decoded_boundary_patches(
     *,
     images: list[Any],
     assembly_plan: dict[str, Any],
     analyses: list[VideoBoundaryAnalysis],
     enable_exposure_ramp: bool = False,
-) -> tuple[list[Any], dict[int, str]]:
-    """Normalize qualified transient exposure shifts without changing motion."""
+) -> tuple[dict[int, torch.Tensor], dict[int, str]]:
+    """Build only the corrected retained boundary frames for qualified seams."""
 
     plan = validate_assembly_plan(assembly_plan)
     chunks = list(plan["chunks"])
     if len(images) != len(chunks):
         raise ValueError("decoded image count does not match the assembly plan")
-    corrected = list(images)
+
+    patches: dict[int, torch.Tensor] = {}
     actions: dict[int, str] = {}
     for analysis in analyses:
         boundary = int(analysis.boundary_index)
-        correction_kind = "transient flash"
-        replace_frames = int(analysis.recommended_rewind)
-        if analysis.micro_flash_candidate:
-            correction_kind = "micro-flash"
-            replace_frames = 1
-        elif enable_exposure_ramp and analysis.exposure_ramp_candidate:
-            correction_kind = "exposure ramp"
-            replace_frames = 4
+        correction_kind, replace_frames = _correction_kind_and_count(
+            analysis,
+            enable_exposure_ramp=enable_exposure_ramp,
+        )
         if replace_frames <= 0:
             actions[boundary] = "kept native boundary"
             continue
@@ -453,6 +466,7 @@ def correct_decoded_boundaries(
         ):
             actions[boundary] = "kept native boundary; correction guard rejected candidate"
             continue
+
         previous_index = boundary - 1
         current_index = boundary
         if previous_index < 0 or current_index >= len(images):
@@ -472,30 +486,66 @@ def correct_decoded_boundaries(
         previous_segment = previous_raw[:previous_total][previous_trim:]
         if int(previous_segment.shape[0]) < 1:
             raise ValueError("video seam correction has no previous retained frame")
-        current_cpu = current_raw.detach().to(device="cpu").clone()
+
+        # Only 1-4 retained boundary frames are owned by the correction. The old
+        # implementation cloned the entire current decoded chunk, which multiplied
+        # host RAM at high resolutions for no semantic benefit.
+        patch = (
+            current_raw[current_trim : current_trim + replace_frames]
+            .detach()
+            .to(device="cpu")
+            .clone()
+        )
         previous_anchor = previous_segment[-1].detach().to(
             device="cpu", dtype=torch.float32
         )
-        recovery_anchor = current_cpu[current_trim + replace_frames].to(
-            dtype=torch.float32
+        recovery_anchor = current_raw[current_trim + replace_frames].detach().to(
+            device="cpu", dtype=torch.float32
         )
         if tuple(previous_anchor.shape) != tuple(recovery_anchor.shape):
             raise ValueError("decoded image geometry changed at video seam")
+
         for offset in range(replace_frames):
             alpha = float(offset + 1) / float(replace_frames + 1)
-            original = current_cpu[current_trim + offset].to(dtype=torch.float32)
+            original = patch[offset].to(dtype=torch.float32)
             target = torch.lerp(previous_anchor, recovery_anchor, alpha)
             original_mean = original.mean(dim=(0, 1), keepdim=True)
             target_mean = target.mean(dim=(0, 1), keepdim=True)
             normalized = (original + target_mean - original_mean).clamp(0.0, 1.0)
-            current_cpu[current_trim + offset].copy_(
-                normalized.to(dtype=current_cpu.dtype)
-            )
-        corrected[current_index] = current_cpu
+            patch[offset].copy_(normalized.to(dtype=patch.dtype))
+
+        patches[current_index] = patch
         actions[boundary] = (
             f"normalized exposure/color on {replace_frames} {correction_kind} "
             "boundary frame(s)"
         )
+    return patches, actions
+
+
+def correct_decoded_boundaries(
+    *,
+    images: list[Any],
+    assembly_plan: dict[str, Any],
+    analyses: list[VideoBoundaryAnalysis],
+    enable_exposure_ramp: bool = False,
+) -> tuple[list[Any], dict[int, str]]:
+    """Compatibility helper returning corrected full chunks for legacy callers."""
+
+    plan = validate_assembly_plan(assembly_plan)
+    chunks = list(plan["chunks"])
+    patches, actions = build_decoded_boundary_patches(
+        images=images,
+        assembly_plan=plan,
+        analyses=analyses,
+        enable_exposure_ramp=enable_exposure_ramp,
+    )
+    corrected = list(images)
+    for current_index, patch in patches.items():
+        current_raw = images[current_index]
+        current_trim = int(chunks[current_index]["trim_frames"])
+        current_cpu = current_raw.detach().to(device="cpu").clone()
+        current_cpu[current_trim : current_trim + int(patch.shape[0])].copy_(patch)
+        corrected[current_index] = current_cpu
     return corrected, actions
 
 

--- a/web/v34_ui.js
+++ b/web/v34_ui.js
@@ -5,6 +5,18 @@ const ASSEMBLER = "H3ContinuumAssembleSeamV34";
 const BASE_REFERENCE_INPUTS = 3;
 const MAX_REFERENCE_INPUTS = 8;
 const REFERENCE_NAME = /^reference_image_(\d+)$/;
+const LEGACY_CONTINUATION = "Guide / Motion Context";
+const NATIVE_CONTINUATION = "Native Masked — exact continuation (Recommended)";
+const CONTINUITY_AUTO = "Auto — conservative";
+const CONTINUITY_BALANCED = "Balanced — 22 frames";
+const CONTINUITY_FAST = "Fast — 5 frames";
+const CONTINUITY_STRONG = "Strong — 39 frames";
+const CONTINUITY_ALL = [
+    CONTINUITY_AUTO,
+    CONTINUITY_BALANCED,
+    CONTINUITY_FAST,
+    CONTINUITY_STRONG,
+];
 const SETTINGS = {
     detailedReport: "H3Continuum.DetailedReport",
     developerDiagnostics: "H3Continuum.DeveloperDiagnostics",
@@ -115,8 +127,29 @@ function regenerateOptions(chunks) {
     return ["Auto", ...Array.from({ length: count }, (_, index) => `Chunk ${index + 1}`)];
 }
 
+function reconcileContinuity(node) {
+    const continuity = findWidget(node, "continuity");
+    if (!continuity) return;
+    const chunks = Number.parseInt(findWidget(node, "chunks")?.value, 10) || 1;
+    const method = findWidget(node, "continuation_method")?.value;
+    const audioContinuity = Boolean(findWidget(node, "audio_continuity")?.value);
+    const generatedAudioExactAv = (
+        chunks > 1
+        && method === NATIVE_CONTINUATION
+        && audioContinuity
+        && !linkedInput(node, ["driving_audio"])
+    );
+    const values = generatedAudioExactAv
+        ? [CONTINUITY_AUTO, CONTINUITY_STRONG]
+        : CONTINUITY_ALL;
+    continuity.options ||= {};
+    continuity.options.values = values;
+    if (!values.includes(continuity.value)) continuity.value = CONTINUITY_STRONG;
+}
+
 function refreshSampler(node) {
     reconcileReferences(node);
+    reconcileContinuity(node);
     const project = findWidget(node, "project_id");
     if (project && !String(project.value || "").trim()) project.value = createProjectId();
 
@@ -167,6 +200,27 @@ function refreshAssembler(node) {
     node.setDirtyCanvas?.(true, true);
 }
 
+function serializedContinuationMethod(info) {
+    const named = info?.widgets_values_named;
+    if (named && typeof named === "object" && Object.hasOwn(named, "continuation_method")) {
+        return named.continuation_method;
+    }
+    return undefined;
+}
+
+function migrateLegacySampler(node, info) {
+    if (!info || node.__h3ContinuumV34ContinuationMigrated) return;
+    const method = findWidget(node, "continuation_method");
+    if (!method) return;
+    // Saved V3.4 graphs before Native Masked had no continuation_method widget.
+    // Preserve their old guide/RoPE semantics instead of silently changing the
+    // generation contract. Newly created nodes retain the backend Native default.
+    if (serializedContinuationMethod(info) === undefined) {
+        method.value = LEGACY_CONTINUATION;
+    }
+    node.__h3ContinuumV34ContinuationMigrated = true;
+}
+
 function install(node) {
     if (!node || node.__h3ContinuumV34Installed) return;
     const type = String(node.comfyClass || node.type || "");
@@ -185,10 +239,17 @@ function install(node) {
     const previousConfigure = node.onConfigure;
     node.onConfigure = function (...args) {
         const result = previousConfigure?.apply(this, args);
+        if (type === SAMPLER) migrateLegacySampler(this, args[0]);
         queueMicrotask(refresh);
         return result;
     };
-    for (const widgetName of ["chunks", "run_storage", "reroll_from_chunk"]) {
+    for (const widgetName of [
+        "chunks",
+        "run_storage",
+        "reroll_from_chunk",
+        "continuation_method",
+        "audio_continuity",
+    ]) {
         const widget = findWidget(node, widgetName);
         if (!widget || widget.__h3ContinuumV34Callback) continue;
         const previous = widget.callback;
@@ -234,6 +295,8 @@ app.registerExtension({
                     apiNode.inputs.diagnostics = settingValue(SETTINGS.detailedReport, false)
                         ? "Detailed Report"
                         : "Basic";
+                    const continuity = findWidget(node, "continuity");
+                    if (continuity) apiNode.inputs.continuity = continuity.value;
                 }
             } else if (type === ASSEMBLER) {
                 refreshAssembler(node);

--- a/web/v34_ui.js
+++ b/web/v34_ui.js
@@ -1,0 +1,250 @@
+import { app } from "../../scripts/app.js";
+
+const SAMPLER = "H3ContinuumSamplerV34";
+const ASSEMBLER = "H3ContinuumAssembleSeamV34";
+const BASE_REFERENCE_INPUTS = 3;
+const MAX_REFERENCE_INPUTS = 8;
+const REFERENCE_NAME = /^reference_image_(\d+)$/;
+const SETTINGS = {
+    detailedReport: "H3Continuum.DetailedReport",
+    developerDiagnostics: "H3Continuum.DeveloperDiagnostics",
+    samplingPreview: "H3Continuum.SamplingPreview",
+};
+
+function settingValue(id, fallback) {
+    try {
+        return app.ui?.settings?.getSettingValue?.(id) ?? fallback;
+    } catch {
+        return fallback;
+    }
+}
+
+function createProjectId() {
+    if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function findWidget(node, name) {
+    return node.widgets?.find((widget) => widget.name === name);
+}
+
+function setWidgetVisible(widget, visible) {
+    if (!widget) return;
+    if (!widget.__h3ContinuumV34Original) {
+        widget.__h3ContinuumV34Original = {
+            type: widget.type,
+            computeSize: widget.computeSize,
+            hidden: widget.hidden,
+            optionsHidden: widget.options?.hidden,
+        };
+    }
+    widget.options ||= {};
+    if (visible) {
+        const original = widget.__h3ContinuumV34Original;
+        widget.type = original.type;
+        widget.computeSize = original.computeSize;
+        widget.hidden = original.hidden;
+        if (original.optionsHidden === undefined) delete widget.options.hidden;
+        else widget.options.hidden = original.optionsHidden;
+    } else {
+        widget.hidden = true;
+        widget.type = "converted-widget";
+        widget.options.hidden = true;
+        widget.computeSize = () => [0, -4];
+    }
+}
+
+function linkedInput(node, names) {
+    return node.inputs?.some((input) => names.includes(input.name) && input.link != null) ?? false;
+}
+
+function referenceIndex(input) {
+    const match = REFERENCE_NAME.exec(String(input?.name ?? ""));
+    if (!match) return 0;
+    const index = Number(match[1]);
+    return Number.isInteger(index) && index >= 1 && index <= MAX_REFERENCE_INPUTS ? index : 0;
+}
+
+function reconcileReferences(node) {
+    if (node.__h3ContinuumV34RefUpdating) return;
+    node.__h3ContinuumV34RefUpdating = true;
+    try {
+        const refs = new Map();
+        let highestPresent = BASE_REFERENCE_INPUTS;
+        let highestConnected = 0;
+        for (const input of node.inputs || []) {
+            const index = referenceIndex(input);
+            if (!index) continue;
+            refs.set(index, input);
+            highestPresent = Math.max(highestPresent, index);
+            if (input.link != null) highestConnected = Math.max(highestConnected, index);
+        }
+        const addThrough = (highest) => {
+            for (let index = BASE_REFERENCE_INPUTS + 1; index <= highest; index += 1) {
+                if (refs.has(index)) continue;
+                node.addInput?.(`reference_image_${index}`, "IMAGE");
+                const added = node.inputs?.[node.inputs.length - 1];
+                if (added) refs.set(index, added);
+            }
+        };
+        addThrough(highestPresent);
+        const desiredHighest = Math.min(
+            MAX_REFERENCE_INPUTS,
+            Math.max(BASE_REFERENCE_INPUTS, highestConnected + 1),
+        );
+        addThrough(desiredHighest);
+        for (let index = MAX_REFERENCE_INPUTS; index > desiredHighest; index -= 1) {
+            const input = refs.get(index);
+            if (!input || input.link != null) continue;
+            const slot = node.inputs?.findIndex((candidate) => referenceIndex(candidate) === index) ?? -1;
+            if (slot >= 0) node.removeInput?.(slot);
+            refs.delete(index);
+        }
+    } finally {
+        node.__h3ContinuumV34RefUpdating = false;
+    }
+}
+
+function regenerateOptions(chunks) {
+    const count = Math.max(1, Math.min(16, Number.parseInt(chunks, 10) || 1));
+    return ["Auto", ...Array.from({ length: count }, (_, index) => `Chunk ${index + 1}`)];
+}
+
+function refreshSampler(node) {
+    reconcileReferences(node);
+    const project = findWidget(node, "project_id");
+    if (project && !String(project.value || "").trim()) project.value = createProjectId();
+
+    const diagnostics = findWidget(node, "diagnostics");
+    const debug = findWidget(node, "debug");
+    const preview = findWidget(node, "show_preview");
+    const strict = findWidget(node, "strict_compatibility");
+    if (diagnostics) diagnostics.value = settingValue(SETTINGS.detailedReport, false) ? "Detailed Report" : "Basic";
+    if (debug) debug.value = Boolean(settingValue(SETTINGS.developerDiagnostics, false));
+    if (preview) preview.value = Boolean(settingValue(SETTINGS.samplingPreview, true));
+    if (strict) strict.value = false;
+    for (const widget of [diagnostics, debug, preview, strict, project]) setWidgetVisible(widget, false);
+
+    const chunks = findWidget(node, "chunks");
+    const regenerate = findWidget(node, "reroll_from_chunk");
+    const storage = findWidget(node, "run_storage");
+    const nonce = findWidget(node, "reroll_nonce");
+    const runName = findWidget(node, "run_name");
+    if (chunks && regenerate) {
+        regenerate.options ||= {};
+        regenerate.options.values = regenerateOptions(chunks.value);
+        if (!regenerate.options.values.includes(regenerate.value)) regenerate.value = "Auto";
+    }
+    const storageEnabled = storage?.value === "Save + Auto Resume";
+    const explicitRegeneration = storageEnabled && regenerate?.value !== "Auto";
+    setWidgetVisible(regenerate, storageEnabled);
+    setWidgetVisible(runName, storageEnabled);
+    setWidgetVisible(nonce, explicitRegeneration);
+    setWidgetVisible(
+        findWidget(node, "reference_size"),
+        linkedInput(node, Array.from({ length: MAX_REFERENCE_INPUTS }, (_, index) => `reference_image_${index + 1}`)),
+    );
+    setWidgetVisible(
+        findWidget(node, "video_reference_size"),
+        linkedInput(node, ["reference_video_1"]),
+    );
+    node.setDirtyCanvas?.(true, true);
+    return project;
+}
+
+function refreshAssembler(node) {
+    const exact = findWidget(node, "exact_total_duration");
+    const diagnostics = findWidget(node, "diagnostics");
+    if (exact) exact.value = true;
+    if (diagnostics) diagnostics.value = settingValue(SETTINGS.detailedReport, false) ? "Detailed Report" : "Basic";
+    setWidgetVisible(exact, false);
+    setWidgetVisible(diagnostics, false);
+    node.setDirtyCanvas?.(true, true);
+}
+
+function install(node) {
+    if (!node || node.__h3ContinuumV34Installed) return;
+    const type = String(node.comfyClass || node.type || "");
+    if (type !== SAMPLER && type !== ASSEMBLER) return;
+    node.__h3ContinuumV34Installed = true;
+    const refresh = () => {
+        if (type === SAMPLER) refreshSampler(node);
+        else refreshAssembler(node);
+    };
+    const previousConnections = node.onConnectionsChange;
+    node.onConnectionsChange = function (...args) {
+        const result = previousConnections?.apply(this, args);
+        queueMicrotask(refresh);
+        return result;
+    };
+    const previousConfigure = node.onConfigure;
+    node.onConfigure = function (...args) {
+        const result = previousConfigure?.apply(this, args);
+        queueMicrotask(refresh);
+        return result;
+    };
+    for (const widgetName of ["chunks", "run_storage", "reroll_from_chunk"]) {
+        const widget = findWidget(node, widgetName);
+        if (!widget || widget.__h3ContinuumV34Callback) continue;
+        const previous = widget.callback;
+        widget.callback = function (value, ...args) {
+            const result = previous?.call(this, value, ...args);
+            queueMicrotask(refresh);
+            return result;
+        };
+        widget.__h3ContinuumV34Callback = true;
+    }
+    queueMicrotask(refresh);
+}
+
+app.registerExtension({
+    name: "H3Continuum.V34UI",
+    nodeCreated(node) {
+        install(node);
+    },
+    loadedGraphNode(node) {
+        install(node);
+    },
+    afterConfigureGraph() {
+        for (const node of app.graph?._nodes || []) install(node);
+    },
+    async beforeQueuePrompt(prompt) {
+        const seen = new Set();
+        for (const node of app.graph?._nodes || []) {
+            const type = String(node.comfyClass || node.type || "");
+            if (type === SAMPLER) {
+                const project = refreshSampler(node);
+                let projectId = String(project?.value || "").trim();
+                if (!projectId || seen.has(projectId)) {
+                    projectId = createProjectId();
+                    if (project) project.value = projectId;
+                }
+                seen.add(projectId);
+                const apiNode = prompt.output?.[String(node.id)];
+                if (apiNode?.inputs) {
+                    apiNode.inputs.project_id = projectId;
+                    apiNode.inputs.strict_compatibility = false;
+                    apiNode.inputs.debug = Boolean(settingValue(SETTINGS.developerDiagnostics, false));
+                    apiNode.inputs.show_preview = Boolean(settingValue(SETTINGS.samplingPreview, true));
+                    apiNode.inputs.diagnostics = settingValue(SETTINGS.detailedReport, false)
+                        ? "Detailed Report"
+                        : "Basic";
+                }
+            } else if (type === ASSEMBLER) {
+                refreshAssembler(node);
+                const apiNode = prompt.output?.[String(node.id)];
+                if (apiNode?.inputs) {
+                    apiNode.inputs.exact_total_duration = true;
+                    apiNode.inputs.diagnostics = settingValue(SETTINGS.detailedReport, false)
+                        ? "Detailed Report"
+                        : "Basic";
+                }
+            }
+        }
+    },
+});


### PR DESCRIPTION
## Status: withdrawn / closed

This consolidated upstream proposal is intentionally closed following the maintainer's review. It combined too many independent changes across runtime behavior, UI, memory management, reference handling, continuation behavior, and repository automation to be safely reviewed or merged as one upstream change.

The combined implementation will remain fork-specific in `xmarre/ComfyUI-H3-Continuum`. No replacement upstream PR is being opened as part of this work.

### Hybrid-conditioning correction

The maintainer also correctly identified that the proposal had diverged from current V3.4 assumptions around hybrid First Frame / Last Frame / Reference Image conditioning.

The fork contained a concrete bad assumption: its V3.4 facade cleared `first_frame` and `last_frame` whenever any Reference Image was connected, treating Reference mode as destructive precedence. That behavior has now been removed in the fork.

Fork PR `xmarre/ComfyUI-H3-Continuum#14` (`e8b390f`) now treats reference blocks and temporal keyframe guides as orthogonal H3 conditioning:

- Reference Images remain persistent `minimax_refs` / `<Picture N>` conditioning.
- First Frame remains a frame-0 keyframe guide.
- Last Frame remains a final-target keyframe guide.
- First/Last are preserved when references are connected.
- Hybrid I2VA / Last-only / FL2VA mode is tracked separately from the reference contract so Run Storage fingerprints both correctly.
- Native Masked removes only keyframes that compete with its protected continuation prefix while retaining persistent references and a valid final Last Frame.
- Guide / Motion Context retains reference blocks, replaces the old frame-0 guide with continuation context, and preserves/moves the final Last Frame appropriately.
- V3.4 dynamic Reference Image inputs through 8 retain the same hybrid semantics.

The corrective fork tree passed Actions run `32377350971` / #138 on Python 3.10, 3.11, 3.12, and 3.13, including full pytest, Ruff, JS syntax, compile, project/release archive validation, and publisher-toolchain smoke.

The original aggregate diff and discussion remain available in this closed PR for historical reference, but the prior claim that Reference Images should override/discard First/Last is withdrawn.